### PR TITLE
Add ytui-music client to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ List of projects that provide terminal user interfaces
 - [spotui](https://github.com/ceuk/spotui) Spotify client written in Python
 - [timg](https://github.com/hzeller/timg) A terminal image viewer
 - [tizonia-openmax-il](https://github.com/tizonia/tizonia-openmax-il) Command-line cloud music player for Linux with support for Spotify, Google Play Music, YouTube, SoundCloud, Dirble, Plex servers and Chromecast devices
+- [ytui-music] (https://github.com/sudipghimire533/ytui-music) Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.
 
 ## <a name="productivity"></a>Productivity
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ List of projects that provide terminal user interfaces
 - [spotui](https://github.com/ceuk/spotui) Spotify client written in Python
 - [timg](https://github.com/hzeller/timg) A terminal image viewer
 - [tizonia-openmax-il](https://github.com/tizonia/tizonia-openmax-il) Command-line cloud music player for Linux with support for Spotify, Google Play Music, YouTube, SoundCloud, Dirble, Plex servers and Chromecast devices
-- [ytui-music] (https://github.com/sudipghimire533/ytui-music) Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.
+- [ytui-music](https://github.com/sudipghimire533/ytui-music) Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.
 
 ## <a name="productivity"></a>Productivity
 


### PR DESCRIPTION
Addded ytui-musci (https://github.com/sudipghimire533/ytui-music) to the list in Multimedia section

Ytui-music fetches youtube data from invidious, play with mpv and download with youtube-dl. Built with tui-rs and rust, ytui aims to be minimal, configurable and beautiful.

This is the project of my own and I have decided to keep the project maintaining. It is quite useful to those people who loves terminal or don't want to waste resources on youtube browser tab, those who loves tui and those who are seeking for private listening activity.

It feels so nice to be on the list :wink: