### PR TITLE
🔒 Add Bash Script [encrypt.sh]

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ List of projects that provide terminal user interfaces
 - [diary](https://github.com/actuday6418/Diary) A diary app written in Rust that encrypts both text and file data, and can decrypt and build a rich HTML representation of your diary when required.
 - [dive](https://github.com/wagoodman/dive) A tool for exploring each layer in a docker image
 - [emu2](https://github.com/dmsc/emu2) A simple DOS emulator for the Linux text console, supporting basic DOS system calls and console I/O.
+- [encrypt.sh](https://fastsitephp.com/en/documents/file-encryption-bash) A bash script for encrypting files on Linux and Mac using built-in commands; works on large files and includes unit testing.
 - [gif-for-cli](https://github.com/google/gif-for-cli) Convert a gif into ASCII
 - [gobang](https://github.com/TaKO8Ki/gobang) A cross-platform TUI database management tool written in Rust
 - [gpg-tui](https://github.com/orhun/gpg-tui) A terminal user interface for GnuPG


### PR DESCRIPTION
This is a 1500+ line bash script with an easy to use interface for encrypting files. Some feature:
* Works on files of any size including huge files (100s of gigs).
* Works on Ubuntu and Mac without requiring anything else to be installed.
* Works with Windows if using Windows Subsystem for Linux
* Works with Password or Key (keys are securely generated).
* Includes extensive unit testing as part of the script
* Helpful and useful examples when running the script from terminal

It's was designed for compatibility with the PHP Framework of the site. I link to the main site because it shows screenshots and provides technical details. This page won't change and links back to GitHub (main repository and bash script itself).