### PR TITLE
Add clidle under Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ List of projects that provide terminal user interfaces
 
 - [2048-cli](https://github.com/tiehuis/2048-cli) The game 2048 for your Linux terminal
 - [bastet](https://github.com/fph/bastet) Evil falling block game
+- [clidle](https://github.com/ajeetdsouza/clidle) Play Wordle in your terminal. Also works over SSH!
 - [Gameboy Emulator](https://github.com/gabrielrcouto/php-terminal-gameboy-emulator) A PHP Terminal GameBoy Emulator
 - [go-life](https://github.com/sachaos/go-life) Terminal based Conway's Game of Life
 - [Greed](https://gitlab.com/esr/greed) A game of consumption. Eat as much as you can before munching yourself into a corner!


### PR DESCRIPTION
Hey, thanks for creating this project!

[clidle](https://github.com/ajeetdsouza/clidle) is a Wordle clone that can be run in your terminal, and also works over SSH. It's built with Go using Bubbletea.