### PR TITLE
Add git-crecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ List of projects that provide terminal user interfaces
 - [austin-tui](https://github.com/P403n1x87/austin-tui) The top-like text-based user interface for Austin
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output.
 - [gitui](https://github.com/extrawurst/gitui) blazing fast terminal-ui for git written in rust
+- [git-crecord](https://github.com/andrewshadura/git-crecord) interactive selective commit tool
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
 - [mitmproxy](https://www.mitmproxy.org) A free and open source interactive HTTPS proxy


### PR DESCRIPTION
git-crecord is an interactive selective commit tool for Git allowing line-by-line commits without patch editing:
![](https://raw.githubusercontent.com/andrewshadura/git-crecord/main/screenshot.png)