### PR TITLE
fix: description in the wrong line

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ List of projects that provide terminal user interfaces
 ## <a name="libraries"></a>Libraries
 
 - [Ashen](https://github.com/colinta/Ashen) An Elm inspired framework written in Swift
-- [blessings](https://github.com/erikrose/blessings) A Python wrapper lib for ncurses that makes your code pretty to look at, complete with extensions known as [bubbles](https://github.com/charmbracelet/bubbles)
-- [bubbletea](https://github.com/charmbracelet/bubbletea) A Go framework based on Elm to build functional and stateful TUI apps
+- [blessings](https://github.com/erikrose/blessings) A Python wrapper lib for ncurses that makes your code pretty to look at
+- [bubbletea](https://github.com/charmbracelet/bubbletea) A Go framework based on Elm to build functional and stateful TUI apps, complete with extensions known as [bubbles](https://github.com/charmbracelet/bubbles)
 - [FINAL CUT](https://github.com/gansm/finalcut) Library for creating terminal applications with text-based widgets
 - [FTXUI](https://github.com/ArthurSonzogni/FTXUI) 💻 C++ Functional Terminal User Interface. ❤️
 - [gocui](https://github.com/jroimartin/gocui) Minimalist Go package aimed at creating Console User Interfaces


### PR DESCRIPTION
seems like it got mixed up at some point during a merge, bubbles relates to bubbletea.

Signed-off-by: Carlos A Becker <caarlos0@gmail.com>  