### PR TITLE
Adds arttime to misc section, and corrects a sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ List of projects that provide terminal user interfaces
 
 ## <a name="miscellaneous"></a>Miscellaneous
 
-- [asciiMol](https://github.com/dewberryants/asciiMol) Curses based ASCII molecule viewer for linux terminals.
 - [adbtuifm](https://github.com/darkhz/adbtuifm) A TUI file manager for Android, based on the Android Debug Bridge(ADB).
+- [arttime](https://github.com/reportaman/arttime) An app that brings beauty of text-art together with functionality of clock, timer, and pattern-based time manager.
+- [asciiMol](https://github.com/dewberryants/asciiMol) Curses based ASCII molecule viewer for linux terminals.
 - [broot](https://dystroy.org/broot/) A new way to see and navigate directory trees
 - [diary](https://github.com/actuday6418/Diary) A diary app written in Rust that encrypts both text and file data, and can decrypt and build a rich HTML representation of your diary when required.
 - [dive](https://github.com/wagoodman/dive) A tool for exploring each layer in a docker image


### PR DESCRIPTION
[arttime](https://github.com/reportaman/arttime) is a developer-centric tool that aims to bring beauty of text art to their terminal based development environment while offering functionality of a clock, timer, and pattern-based time manager (think Pomodoro, and beyond).