### PR TITLE
Add runme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ List of projects that provide terminal user interfaces
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
 - [tig](https://github.com/jonas/tig) Text-mode interface for git
 - [vctui](https://github.com/thebsdbox/vctui) Console interface for vCenter
+- [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
 ---
 </details>
 


### PR DESCRIPTION
Adding [runme](https://runme.dev/), a CLI that allows discover and run code snippets directly from your README.md or other markdowns