### PR TITLE
Update Ratatui to highlight that it's a Rust crate and deprecate tui-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ List of projects that provide terminal user interfaces
 - [textual](https://github.com/willmcgugan/textual) is a TUI (Text User Interface) framework for Python inspired by modern web development.
 - [Thermage](https://github.com/thermage/thermage) Thermage is a PHP library that provides a fluent and incredibly powerful, object-oriented interface for customizing CLI output text color, background, formatting, theming and more.
 - [tui-go](https://github.com/marcusolsson/tui-go) A UI library for terminal applications (deprecated)
-- [tui-rs](https://github.com/fdehau/tui-rs) Terminal user interfaces and dashboards using Rust (no longer maintained, use [ratatui](https://github.com/tui-rs-revival/ratatui) instead).
+- [tui-rs](https://github.com/fdehau/tui-rs) Terminal user interfaces and dashboards using Rust (no longer maintained, use Ratatui instead).
 - [tuibox](https://github.com/Cubified/tuibox) A single-header terminal UI library, capable of creating mouse-driven, interactive applications on the command line.
 - [tview](https://github.com/rivo/tview/) Terminal UI library with rich, interactive widgets — written in Golang
 - [tvision](https://github.com/magiblot/tvision) A modern port of Turbo Vision 2.0, cross-platform and Unicode support.

--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ List of projects that provide terminal user interfaces
 - [pytermgui](https://github.com/bczsalba/pytermgui) A simple yet powerful TUI framework for your Python (3.7+) applications.
 - [pyTermTk](https://github.com/ceccopierangiolieugenio/pyTermTk) self-contained TUI library for Python with a QT-like API semantics
 - [Python Prompt Toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) Library for building powerful interactive command line applications in Python
-- [ratatui](https://github.com/tui-rs-revival/ratatui) tui-rs revival project
+- [Ratatui](https://github.com/tui-rs-revival/ratatui) A Rust crate for building Terminal UIs (actively maintained fork of tui-rs).
 - [Rich](https://github.com/willmcgugan/rich) is a Python library for rich text and beautiful formatting in the terminal.
 - [tcell](https://github.com/gdamore/tcell) Tcell is an alternate terminal package, similar in some ways to termbox, but better in others.
 - [textual](https://github.com/willmcgugan/textual) is a TUI (Text User Interface) framework for Python inspired by modern web development.
 - [Thermage](https://github.com/thermage/thermage) Thermage is a PHP library that provides a fluent and incredibly powerful, object-oriented interface for customizing CLI output text color, background, formatting, theming and more.
 - [tui-go](https://github.com/marcusolsson/tui-go) A UI library for terminal applications (deprecated)
-- [tui-rs](https://github.com/fdehau/tui-rs) Terminal user interfaces and dashboards using Rust
+- [tui-rs](https://github.com/fdehau/tui-rs) Terminal user interfaces and dashboards using Rust (no longer maintained, use [ratatui](https://github.com/tui-rs-revival/ratatui) instead).
 - [tuibox](https://github.com/Cubified/tuibox) A single-header terminal UI library, capable of creating mouse-driven, interactive applications on the command line.
 - [tview](https://github.com/rivo/tview/) Terminal UI library with rich, interactive widgets — written in Golang
 - [tvision](https://github.com/magiblot/tvision) A modern port of Turbo Vision 2.0, cross-platform and Unicode support.


### PR DESCRIPTION
I wasn't sure whether to drop tui-rs completely, but we're full steam ahead with ratatui development, whereas tui-rs stopped a while ago.