### PR TITLE
Refine the classification of AdGuardian-Term

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ List of projects that provide terminal user interfaces
 
 <details open><summary><h2>Dashboards</h2></summary>
 
+- [AdGuardian-Term](https://github.com/lissy93/AdGuardian-Term) A TUI dashboard for monitoring real-time traffic from an AdGuard Home instance.
 - [bashtop](https://github.com/aristocratos/bashtop) Resource manager written in bash
 - [below](https://github.com/facebookincubator/below) A time traveling resource monitor for modern Linux systems
 - [bmon](https://github.com/tgraf/bmon) A monitoring and debugging tool to capture networking related statistics and prepare them visually.
@@ -220,7 +221,6 @@ List of projects that provide terminal user interfaces
 <details open><summary><h2>Miscellaneous</h2></summary>
 
 - [adbtuifm](https://github.com/darkhz/adbtuifm) A TUI file manager for Android, based on the Android Debug Bridge(ADB).
-- [adguardian](https://github.com/lissy93/AdGuardian-Term) A TUI dashboard for monitoring real-time traffic from an AdGuard Home instance.
 - [arttime](https://github.com/reportaman/arttime) An app that brings beauty of text-art together with functionality of clock, timer, and pattern-based time manager.
 - [asciiMol](https://github.com/dewberryants/asciiMol) Curses based ASCII molecule viewer for linux terminals.
 - [bluetuith](https://github.com/darkhz/bluetuith) A TUI-based bluetooth connection manager, which can interact with bluetooth adapters and devices.


### PR DESCRIPTION
Given that AdGuardian-Term is a terminal-based tool offering real-time traffic monitoring and statistics for AdGuard Home instance, it is appropriately classified in the dashboard category.