### PR TITLE
add pream-team to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ List of projects that provide terminal user interfaces
 - [patat](https://github.com/jaspervdj/patat) Terminal-based presentations using Pandoc
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support
 - [pkm](https://github.com/wick3dr0se/pkm) A super minimal TUI package manager wrapper written in BASH v4.2+
+- [pream-team](https://github.com/nikoladucak/pream-team/) a TUI utility that helps you keep track of your teams GitHub PRs across multiple repositories
 - [procmux](https://github.com/napisani/procmux) - a TUI for running multiple commands in parallel in easily switchable terminals
 - [productivity-timer](https://github.com/h-sifat/productivity-timer) A command line time tracker application with a sleek TUI.
 - [ranger](https://github.com/ranger/ranger) A VIM-inspired filemanager for the console


### PR DESCRIPTION
pream-team is a simple TUI app that helps you keep track of GitHub pull requests for your team. This gives you a nice overview of which PRs you've approved/commented/requested changes on, even if your team is touching multiple repositories in your org.