### PR TITLE
Remove spotify-tui & Add spotify-player.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ List of projects that provide terminal user interfaces
 - [RadioGoGo](https://github.com/Zi0P4tch0/RadioGoGo) Go-powered CLI to surf global radio waves via a sleek TUI.
 - [roku-cli](https://github.com/winsbe01/roku-cli) A command line TUI remote for Roku
 - [soundcloud2000](https://github.com/grobie/soundcloud2000) A terminal client for soundcloud
-- [spotify-tui](https://github.com/Rigellute/spotify-tui) Spotify for the terminal written in Rust
+- [spotify-player](https://github.com/aome510/spotify-player) A Spotify player in the terminal with full feature parity
 - [spotui](https://github.com/ceuk/spotui) Spotify client written in Python
 - [terminal-yt](https://github.com/jooooscha/terminal-yt) A small newsboat-inspired terminal youtube manager
 - [textual-paint](https://github.com/1j01/textual-paint) MS Paint in your terminal


### PR DESCRIPTION
Hi!

Due to [this spotify-tui issue](https://github.com/Rigellute/spotify-tui/issues/1000) I've removed spotify-tui from the list as it's no longer in a stable state.

Instead I've replaced it with the similar and equally awesome [spotify-player](https://github.com/aome510/spotify-player) which is a Rust based spotify tui client.

Please merge or leave feedback as you see fit.