### PR TITLE
Add macmon

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ List of projects that provide terminal user interfaces
 - [k9s](https://github.com/derailed/k9s) TUI for managing a Kubernetes cluster
 - [kmon](https://github.com/orhun/kmon) Linux Kernel Manager and Activity Monitor
 - [lazydocker](https://github.com/jesseduffield/lazydocker) The lazier way to manage everything docker
+- [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
 - [netscanner](https://github.com/Chleba/netscanner) Network scanner
 - [nnn](https://github.com/jarun/nnn) n³ The unorthodox terminal file manager
 - [nvtop](https://github.com/Syllo/nvtop) GPUs process monitoring for AMD, Intel and NVIDIA


### PR DESCRIPTION
Hi. Thank you for this collection of useful TUI programs! I would like to add one more:

[`macmon`](https://github.com/vladkens/macmon) - sudoless performance / power monitoring TUI for Apple Silicon processors.