### PR TITLE
Add x-cmd to the Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ List of projects that provide terminal user interfaces
 - [WG Commander](https://github.com/andrianbdn/wg-cmd) A TUI for a simple WireGuard VPN setup: peer management, QR codes, setup wizard.
 - [wttr.in](https://github.com/chubin/wttr.in) The right way to check the weather
 - [xplr](https://github.com/sayanarijit/xplr) A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf.
-- [x-cmd](https://github.com/x-cmd/x-cmd) x-cmd is a vast and interesting collection of tools  that can then bootstrap lots of other programs / functions in a consistent and structured way.
+- [x-cmd](https://github.com/x-cmd/x-cmd) A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
 - [yazi](https://github.com/sxyazi/yazi) Blazing fast terminal file manager written in Rust, based on async I/O.
 ---
 </details>

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ List of projects that provide terminal user interfaces
 - [WG Commander](https://github.com/andrianbdn/wg-cmd) A TUI for a simple WireGuard VPN setup: peer management, QR codes, setup wizard.
 - [wttr.in](https://github.com/chubin/wttr.in) The right way to check the weather
 - [xplr](https://github.com/sayanarijit/xplr) A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf.
+- [x-cmd](https://github.com/x-cmd/x-cmd) x-cmd is a vast and interesting collection of tools  that can then bootstrap lots of other programs / functions in a consistent and structured way.
 - [yazi](https://github.com/sxyazi/yazi) Blazing fast terminal file manager written in Rust, based on async I/O.
 ---
 </details>


### PR DESCRIPTION
Hi. Thank you for this collection of useful TUI programs!
I want to add x-cmd to the list.
I have searched the PRs of this repo and believe that this is not a duplicate.

x-cmd is a toolset implemented using posix shell and awk. It is very small in size and offers many interesting features.

**Tools Provided by x-cmd:**
  - [Wrappers for Common Commands (e.g., cd, ip, ps, tar, apt, brew)](https://x-cmd.com/mod/zuz): These wrapped commands are more intelligent and easier to use compared to the native commands.
  - [Lightweight Package Management Tool](https://x-cmd.com/pkg/): We have implemented a lightweight package management tool using shell and awk. Through it, you can quickly obtain most common software tools, such as jq, 7za, bat, nvim, python, node, go, etc.
  - [CLI for Useful Websites (e.g., github.com, cht.sh)](https://x-cmd.com/mod/cht): We have wrapped their APIs using shell and awk for daily use and to obtain corresponding services in scripts.
  - [AI Tools](https://x-cmd.com/mod/openai): We provide CLIs for ChatGPT, Gemini, Jina.ai, etc., and have wrapped corresponding shortcut commands for different application scenarios, such as `@gemini` for chatting with Gemini AI and `@zh` for using AI to translate specified content or command results.
