### PR TITLE
Add fewlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ List of projects that provide terminal user interfaces
 - [blessings](https://github.com/erikrose/blessings) A **Python** wrapper lib for ncurses that makes your code pretty to look at
 - [bubbletea](https://github.com/charmbracelet/bubbletea) A **Go** framework based on Elm to build functional and stateful TUI apps, complete with extensions known as [bubbles](https://github.com/charmbracelet/bubbles)
 - [CursedGL](https://github.com/saccharineboi/CursedGL) A **C** notcurses-based software rasterizer inspired by OpenGL 1.X that renders directly to the terminal.
+- [fewlines](https://github.com/okuvshynov/fewlines) A **Python** /**C++** library for compact, text-based charts in command-line and log files. Creates minimalist histograms, time series, and dashboards using few lines of text.
 - [FINAL CUT](https://github.com/gansm/finalcut) **C++** library for creating terminal applications with text-based widgets
 - [FTXUI](https://github.com/ArthurSonzogni/FTXUI) 💻 **C++** Functional Terminal User Interface. ❤️
 - [gocui](https://github.com/jroimartin/gocui) Minimalist **Go** package aimed at creating Console User Interfaces


### PR DESCRIPTION
[fewlines](https://github.com/okuvshynov/fewlines) is a Python/C++ library for creating compact, text-based visualizations in command-line outputs and log files. It generates minimalist histograms, time series charts, and dashboards using only a few lines of text. Ideal for quick data representation in terminals or for logging multi-chart dashboards.