### PR TITLE
Add abook

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ List of projects that provide terminal user interfaces
 
 <details open><summary><h2>Productivity</h2></summary>
 
+- [abook](https://abook.sourceforge.io/) TUI addressbook with [mutt](http://www.mutt.org/) integration
 - [calcure](https://github.com/anufrievroman/calcure) Modern TUI calendar and task manager with minimal and customizable UI.
 - [calcurse](https://calcurse.org/) calendar and scheduling application for the command line
 - [elia](https://github.com/darrenburns/elia) A terminal ChatGPT client build with Textual


### PR DESCRIPTION
Add a mention to abook, an early Linux addressbook from the early 1990s.

Although many distros have stopped packaging this, it can still be found in the Debian repos, or compiled manually.