### PR TITLE
Add cfdisk and cgdisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ List of projects that provide terminal user interfaces
 - [bluetui](https://github.com/pythops/bluetui) A TUI for managing bluetooth devices.
 - [Captain's log](https://github.com/NikolaDucak/caps-log) A small TUI journaling tool
 - [cava](https://github.com/karlstav/cava) Cross-platform Audio Visualizer
+- [cfdisk](https://github.com/util-linux/util-linux) TUI partition editor included in util-linux
+- [cgdisk](https://www.rodsbooks.com/gdisk/cgdisk-walkthrough.html) TUI partition editor for manipulating GUID partition tables, and modeled after cfdisk
 - [diary](https://github.com/actuday6418/Diary) A diary app written in Rust that encrypts both text and file data, and can decrypt and build a rich HTML representation of your diary when required.
 - [diskonaut](https://github.com/imsnif/diskonaut) Terminal disk space navigator
 - [distrobox-tui](https://github.com/hyperreal64/distrobox-tui) TUI for managing distrobox containers


### PR DESCRIPTION
cfdisk is part of util-linux, included in nearly every Linux distro. cgdisk was written by the same author as gdisk, and was modeled after gdisk.