### PR TITLE
Update URL for moulti.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ List of projects that provide terminal user interfaces
 - [ink](https://github.com/vadimdemedes/ink) React for **Node.js** interactive command-line apps
 - [iocraft](https://github.com/ccbrown/iocraft) **Rust** crate for beautiful, artisanally crafted TUIs and text-based IO, with a declarative, React-like API inspired by Ink.
 - [Lanterna](https://github.com/mabe02/lanterna) A **Java** library for creating text-based UIs, very similar to the C library curses but with more functionality.
-- [moulti](https://github.com/xavierog/moulti) A CLI-driven TUI displaying arbitrary outputs inside visual, collapsible blocks. Designed with **shell** scripts in mind. **Ansible**-friendly too.
+- [moulti](https://moulti.run/) A CLI-driven TUI displaying arbitrary outputs inside visual, collapsible blocks. Designed with **shell** scripts in mind. **Ansible**-friendly too.
 - [ncurses](https://invisible-island.net/ncurses/announce.html) A classic **C** library with bindings for many languages
 - [nimwave](https://github.com/ansiwave/nimwave) Build text interfaces for the terminal or browser in **Nim**
 - [notcurses](https://github.com/dankamongmen/notcurses) blingful character graphics/TUI library for **C** and **Python**. definitely not curses.


### PR DESCRIPTION
Moulti is still available at https://github.com/xavierog/moulti but https://moulti.run/ is more user-friendly.