### PR TITLE
Add SSH Slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ List of projects that provide terminal user interfaces
 - [sc-im](https://github.com/andmarti1424/sc-im) An ncurses spreadsheet program for terminal. Reignited version of sc
 - [SheetsUI](https://github.com/zaphar/sheetsui) A console based spreadsheet application
 - [slides](https://github.com/maaslalani/slides) A terminal based presentation tool, supporting markdown syntax.
+- [ssh-slides](https://github.com/ivantsepp/ssh-slides) Terminal-based presentations over SSH
 - [taskline](https://github.com/perryrh0dan/taskline) Tasks, boards & notes for the command-line habitat
 - [taskwarrior-tui](https://github.com/kdheepak/taskwarrior-tui) A Terminal User Interface for Taskwarrior
 - [television](https://github.com/alexpasmantier/television) A fast and versatile fuzzy finder TUI


### PR DESCRIPTION
SSH Slides is an SSH server that hosts terminal-based presentations where your viewers can follow along in their own terminals.