### PR TITLE
Add Arduino-CLI-Interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ List of projects that provide terminal user interfaces
 
 <details open><summary><h2>Miscellaneous</h2></summary>
 
+- [arduino-cli-interactive](https://github.com/Vaishnav-Sabari-Girish/arduino-cli-interactive) A tool that makes using arduino-cli easier and interactive for beginners to the terminal.
 - [arttime](https://github.com/reportaman/arttime) An app that brings beauty of text-art together with functionality of clock, timer, and pattern-based time manager.
 - [asciiMol](https://github.com/dewberryants/asciiMol) Curses based ASCII molecule viewer for linux terminals.
 - [bluetuith](https://github.com/darkhz/bluetuith) A TUI-based bluetooth connection manager, which can interact with bluetooth adapters and devices.


### PR DESCRIPTION
**arduino-cli-interactive (ACI)** lets you use **arduino-cli** with an easy, interactive terminal UI—no need to remember board names or type long commands. Just pick options, navigate with buttons, and upload your code hassle-free, all from the terminal!