### PR TITLE
Add otel-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ List of projects that provide terminal user interfaces
 - [netscanner](https://github.com/Chleba/netscanner) Network scanner
 - [nvtop](https://github.com/Syllo/nvtop) GPUs process monitoring for AMD, Intel and NVIDIA
 - [oryx](https://github.com/pythops/oryx) A TUI for sniffing network traffic using eBPF
+- [otel-tui](https://github.com/ymtdzzz/otel-tui) A terminal OpenTelemetry viewer
 - [Planor](https://github.com/mrusme/planor) The Cloud Aviator, dashboard for AWS, Vultr, Heroku, ...
 - [process-compose](https://github.com/F1bonacc1/process-compose) TUI for running apps and processes
 - [Puffin](https://github.com/siddhantac/puffin) A beautiful terminal dashboard for hledger


### PR DESCRIPTION
otel-tui is a terminal OpenTelemetry viewer, supporting OpenTelemetry, Zipkin (Traces) and Prometheus (Metrics) formats.