### PR TITLE
Add zxc proxy to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ List of projects that provide terminal user interfaces
 - [tig](https://github.com/jonas/tig) Text-mode interface for git
 - [vctui](https://github.com/thebsdbox/vctui) Console interface for vCenter
 - [violet](https://github.com/braheezy/violet) Colorful TUI frontend to run Vagrant commands
+- [zxc](https://github.com/hail-hydrant/zxc) A Terminal based mitm Proxy written in rust with Tmux and Vim as user interface.
 
 ---
 </details>


### PR DESCRIPTION
[zxc](https://github.com/hail-hydrant/zxc): A Terminal based mitm proxy written in rust with Tmux and Vim as user interface.