### PR TITLE
Add proxymock tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ List of projects that provide terminal user interfaces
 - [nodebro](https://github.com/jonaburg/nodebro) Easily view most recent Github releases/tags and release notes from the terminal
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq
 - [posting](https://github.com/darrenburns/posting) A powerful HTTP client that lives in your terminal
+- [proxymock](https://proxymock.io) A network recorder that shows API payloads in a TUI and automatically generates tests and mocks from what it observes.
 - [prs](https://github.com/dhth/prs) Stay updated on PRs without leaving the terminal
 - [pudb](https://github.com/inducer/pudb) A console-based visual debugger for Python
 - [pyautogit](https://github.com/jwlodek/pyautogit) A terminal UI for managing git repositories, written using py_cui


### PR DESCRIPTION
Adds the proxymock tui/cli. proxymock is a tool that uses a proxy to intercept inbound and outbound traffic from an app running on the local desktop. All details of the request and response can be navigated in the tui. Recorded calls can be turned into tests and mocks to speed up development. It's like a self contained isolation environment that looks real to the app. The tool is free and self contained as a single cli - it is not a wrapper around another tool and is delivered as a single binary.

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/89e48784-192d-4fcf-884d-e08e7a711f1a" />

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/434389f2-63ae-42ad-be27-dbf8ea30e416" />

