### PR TITLE
add nbcat - Jupyter notebooks (ipynb) viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ List of projects that provide terminal user interfaces
 - [logshark](https://github.com/ugosan/logshark) A debugger CLI for JSON logs written in Go
 - [mitmproxy](https://www.mitmproxy.org) A free and open source interactive HTTPS proxy
 - [nap](https://github.com/maaslalani/nap) Code snippets in your terminal
+- [nbcat](https://github.com/akopdev/nbcat) - Preview Jupyter notebooks (ipynb) in terminal.
 - [nodebro](https://github.com/jonaburg/nodebro) Easily view most recent Github releases/tags and release notes from the terminal
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq
 - [posting](https://github.com/darrenburns/posting) A powerful HTTP client that lives in your terminal


### PR DESCRIPTION
Hi @rothgar,

This is my second attempt ([first one](https://github.com/rothgar/awesome-tuis/pull/302)) to get [nbcat](https://github.com/akopdev/nbcat) into the catalog.

Over the past week, I’ve introduced a couple of features that I believe make **nbcat** a better fit:

- Added support for images  
- Added an interactive mode (paging)