### PR TITLE
add pproftui

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ List of projects that provide terminal user interfaces
 - [nodebro](https://github.com/jonaburg/nodebro) Easily view most recent Github releases/tags and release notes from the terminal
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq
 - [posting](https://github.com/darrenburns/posting) A powerful HTTP client that lives in your terminal
+- [pproftui](https://github.com/Oloruntobi1/pproftui) A terminal-based UI for Go's pprof that makes profiling interactive
 - [proxymock](https://proxymock.io) A network recorder that shows API payloads in a TUI and automatically generates tests and mocks from what it observes.
 - [prs](https://github.com/dhth/prs) Stay updated on PRs without leaving the terminal
 - [pudb](https://github.com/inducer/pudb) A console-based visual debugger for Python


### PR DESCRIPTION
Adds `pproftui` a terminal-based UI for Go's pprof that makes profiling interactive, intuitive, and fast. It's designed to help you pinpoint performance issues without the context-switching of a web browser and to provide built-in explanations for profiling concepts.

<img width="1512" alt="Screenshot 2025-07-07 at 20 04 09" src="https://github.com/user-attachments/assets/b685981f-aa5e-4d30-8ba4-d85e8c9755a3" />

