### PR TITLE
Add csol

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@
 - [cbonsai](https://gitlab.com/jallbrit/cbonsai) A bonsai tree generator
 - [chess-tui](https://github.com/thomas-mauran/chess-tui) Play Chess in your terminal, built in rust
 - [clidle](https://github.com/ajeetdsouza/clidle) Play Wordle in your terminal. Also works over SSH!
+- [csol](https://github.com/nielssp/csol) Collection of solitaire/patience games, such as Klondike, FreeCell, Spider, and Yukon
 - [DOOM-ASCII](https://github.com/wojciech-graj/doom-ascii) Text-based DOOM running in terminal.
 - [Gameboy Emulator](https://github.com/gabrielrcouto/php-terminal-gameboy-emulator) A PHP Terminal GameBoy Emulator
 - [go-life](https://github.com/sachaos/go-life) Terminal based Conway's Game of Life


### PR DESCRIPTION
csol is a small collection of solitaire/patience games, such as Klondike, FreeCell, Spider, and Yukon, to play in the terminal.

Thank you for wanting to contribute to this list! There are many amazing terminal applications and our goal is to provide a place for people to discover them.

There are a few requirements for adding new applications to the list.

- Applications should be unique

    Please don't submit variations of existing applications
- Interfaces should be unique

    Please don't submit output formatters or wrappers (e.g. `fzf`)
- Interfaces should be interactive or re-draw output

    Scripts that accept text prompts are not a good fit for this list
