### PR TITLE
add ConsoleCraftEngine - a terminal game engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - [burf](https://github.com/razeghi71/burf) TUI for Google Cloud Storage (GCS)
 - [cargo-seek](https://github.com/tareqimbasher/cargo-seek) A TUI for searching, adding and installing cargo crates
 - [cnTUI](https://github.com/fipso/cntui) Replay chrome requests from your terminal using curl
+- [ConsoleCraftEngine](https://github.com/ural89/ConsoleCraftEngine) A terminal-based 2D game engine written in C++.
 - [chiko](https://github.com/felangga/chiko) The Ultimate Beauty TUI gRPC Client
 - [Cloud Code Usage Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) Monitor Claude token usage
 - [csope](https://github.com/agvxov/csope) C source code browser based on cscope


### PR DESCRIPTION
add ConsoleCraftEngine - it is a game engine for creating terminal games.