### PR TITLE
add LazySSH – TUI SSH manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@
 - [kabmat](https://github.com/PlankCipher/kabmat) TUI program for managing kanban boards with vim-like keybindings
 - [kanban-python](https://github.com/Zaloog/kanban-python) Kanban Terminal App written in Python
 - [khal](https://github.com/pimutils/khal) A standards based CLI calendar program, able to synchronize with CalDAV servers
+- [LazySSH](https://github.com/adembc/lazyssh) - TUI SSH manager to browse, connect, and manage servers from ssh config files.
 - [levite](https://github.com/RauliL/levite) A TUI spreadsheet application that uses an RPN formulas and features a vi-friendly interface
 - [mcfly](https://github.com/cantino/mcfly) Intelligent context-aware search engine for your shell history
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management for terminal environments


### PR DESCRIPTION
This PR adds [LazySSH](https://github.com/adembc/lazyssh), a terminal-based SSH manager with a keyboard-driven UI that lets you browse, connect, and manage servers directly from ssh config files.

<img width="1497" height="881" alt="lazy" src="https://github.com/user-attachments/assets/29ed6eef-3424-4fc2-861b-804a67b3d0ee" />
