### PR TITLE
Add rustnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [process-compose](https://github.com/F1bonacc1/process-compose) TUI for running apps and processes
 - [Puffin](https://github.com/siddhantac/puffin) A beautiful terminal dashboard for hledger
 - [Raijin](https://github.com/MasonStooksbury/Raijin) A free, simple weather TUI that pulls data without the need for an API key, account, or subscription
+- [rustnet](https://github.com/domcyrus/rustnet)  A cross-platform network monitoring tool with deep packet inspection
 - [s-tui](https://github.com/amanusk/s-tui) CPU stress and monitoring utility
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl


### PR DESCRIPTION
Hi there,

I would like to add [RustNet](https://github.com/domcyrus/rustnet) a cross-platform network monitor that combines real-time traffic with deep packet inspection and process attribution.

**Things that may make it unique:**

1. **Deep Protocol Analysis**: Unlike basic network monitors, RustNet provides deep packet inspection:
   - TLS/HTTPS SNI (Server Name Indication) information
   - QUIC stream analysis and connection details
   - SSH banner information and protocol detection
   - DNS query inspection with response details
   - HTTP/HTTPS metadata extraction

2. **Process Attribution**: Connects network activity directly to the responsible process/application, solving the "what's causing this traffic?" problem. On macOS, as far as I can tell, no other tool uses pktab which makes it possible to identify all processes, including short-lived processes like `curl` or `wget`.

3. **Connection State Tracking**: Monitors connection lifecycle with protocol-specific state information (TCP states, QUIC connection phases, etc.).

4. **Filter option**: Real-time vim/fzf-style filtering with keyword support: 
   - Navigate while typing filters
   - Fuzzy search across all connection fields including DPI data
   - Keyword filters: port:443, src:192.168, process:firefox
