### PR TITLE
adding bulletty, a pretty feed reader that stores articles in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@
 
 - [bombadillo](https://bombadillo.colorfield.space/) A TUI browser for the non-web: Gopher, Gemini, Finger
 - [browsh](https://github.com/browsh-org/browsh) A fully-modern text-based browser, rendering to TTY and browsers
+- [bulletty](https://github.com/CrociDB/bulletty) A pretty feed reader (ATOM/RSS) that stores articles in Markdown files
 - [Canard](https://github.com/mrusme/canard) A command line TUI client for the [Journalist](https://github.com/mrusme/journalist) RSS aggregator.
 - [carbonyl](https://github.com/fathyb/carbonyl) Chromium running inside your terminal
 - [castero](https://github.com/xgi/castero) A TUI app to listen to podcast


### PR DESCRIPTION
Hi,

I'm submitting **bulletty**, a TUI feed reader. Although there are plenty of alternatives, bulletty has some features that are not common in other tools such as storing the articles locally in Markdown files, giving the user full control over their source's content. Also, look n' feel is a major concern of this project, making it a really good experience reading feeds on the terminal. So rather than just aggregating, it's more focusing on reading. Features such as article notes and highlights are not currently implemented, but on the way.

Thanks.

![bulletty4](https://github.com/user-attachments/assets/0a5d0123-c8ea-498f-a689-012d3a4d7af1)
