### PR TITLE
Add wifitui

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@
 - [wb](https://github.com/MertGunduz/wb) A TUI vocabulary notebook app for Linux based devices.
 - [wego](https://github.com/schachmat/wego) Weather app
 - [wavemon](https://github.com/uoaerg/wavemon) A wireless device monitoring application
+- [wifitui](https://github.com/shazow/wifitui) Fast featureful friendly wifi terminal UI, supports NetworkManager and iwd over dbus.
 - [WG Commander](https://github.com/andrianbdn/wg-cmd) A TUI for a simple WireGuard VPN setup: peer management, QR codes, setup wizard.
 - [wttr.in](https://github.com/chubin/wttr.in) The right way to check the weather
 - [xplr](https://github.com/sayanarijit/xplr) A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf.


### PR DESCRIPTION
https://github.com/shazow/wifitui

I hope this fits the requirements. There exist a couple of other wifi TUI apps (nmtui, impala) but neither has all the functionality of the other, and has the functionality of both plus more: fuzzy search, order by recency, QR code sharing, supporting multiple backends, and more.

Hoping wifitui will be the ultimate wifitui anyone needs. :)

There's a screenshot and a list of features on the project page.