### PR TITLE
Add codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - [chiko](https://github.com/felangga/chiko) The Ultimate Beauty TUI gRPC Client
 - [Close Mongo Ops Manager](https://github.com/closeio/close-mongo-ops-manager) Monitor and kill MongoDB operations
 - [Cloud Code Usage Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) Monitor Claude token usage
+- [codex](https://github.com/openai/codex) Lightweight coding agent that runs in your terminal
 - [csope](https://github.com/agvxov/csope) C source code browser based on cscope
 - [CuTE](https://github.com/PThorpe92/CuTE) TUI to help build, execute and save curl commands, recursively download from remote sources, test your API endpoints, and mange your keys
 - [crush](https://github.com/charmbracelet/crush) The glamourous AI coding agent


### PR DESCRIPTION
codex is OpenAI's TUI based Open Source AI coding agent
- You can use it with your ChatGPT account
- Or, with an API key
 
OpenAI made a lot of improvements in codex-cli recently.
So it should definitely be in this list of Awesome TUIs.

*Note:* Previously it was written in Typescript and known as [`codex-cli`](https://github.com/openai/codex/tree/main/codex-cli), but now it's rewritten in Rust and called just `codex`. 