### PR TITLE
Add kanban

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration
 - [Judo](https://github.com/giacomopiccinini/judo) A multi-database TUI for ToDo lists, using Rust + Ratatui + SQLite
 - [kabmat](https://github.com/PlankCipher/kabmat) TUI program for managing kanban boards with vim-like keybindings
+- [kanban](https://github.com/fulsomenko/kanban) - TUI kanban board for projects management with sprint tracking and task prioritization.
 - [kanban-python](https://github.com/Zaloog/kanban-python) Kanban Terminal App written in Python
 - [khal](https://github.com/pimutils/khal) A standards based CLI calendar program, able to synchronize with CalDAV servers
 - [LazySSH](https://github.com/adembc/lazyssh) - TUI SSH manager to browse, connect, and manage servers from ssh config files.


### PR DESCRIPTION

* [crates.io](https://crates.io/crates/kanban-tui) 

* [GitHub](https://github.com/fulsomenko/kanban)

* Description:  A terminal-based kanban/project management tool inspired by [lazygit](https://github.com/jesseduffield/lazygit), built with Rust.

![demo](https://github.com/user-attachments/assets/73cc6508-81ff-4cb0-b121-6dcfd77ee0cc)
