### PR TITLE
Add podliner: a cross platform podcast player

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@
 - [haxor-news](https://github.com/donnemartin/haxor-news) Browse Hacker News like a haxor: A Hacker News command line interface (CLI)
 - [Lagrange](https://gmi.skyjake.fi/lagrange) Lagrange is a cross-platform client for browsing Geminispace
 - [LYNX](https://lynx.invisible-island.net/) A text based Terminal browser
+- [podliner](https://github.com/timkicker/podliner) A cross-platform podcast client
 - [newsboat](https://github.com/newsboat/newsboat) An RSS/Atom feed reader for the text console
 - [nyaa](https://github.com/Beastwick18/nyaa) A nyaa.si TUI for browsing and downloading torrents
 - [omaro](https://github.com/Rolv-Apneseth/omaro) TUI to browse posts and comments on lobste.rs


### PR DESCRIPTION

Project is called **podliner**.
It's a terminal UI podcast client written in C# / .NET 9:

- cross-platform (Linux, macOS, Windows) (x86_64, ARM64)
- Vim-style keybinds (j/k, / search, :engine mpv, etc.)
- real-time playback (mpv / VLC / ffmpeg, with native engine fallback on Windows)
- speed / volume / seek
- offline downloads, queue management
- OPML import/export
- theming 

License: GPLv3.
Repo: github.com/timkicker/podliner
<img width="2257" height="1431" alt="01-episodes" src="https://github.com/user-attachments/assets/ad398017-2a6c-4aaf-b2bb-7f6d5b98ff88" />
<img width="2257" height="1428" alt="02-details" src="https://github.com/user-attachments/assets/7288c381-abad-4314-86fa-4a884910f3a6" />
<img width="2257" height="1443" alt="03-help" src="https://github.com/user-attachments/assets/a7923dd5-2d98-4175-bf5b-7ae2a57489e8" />


