### PR TITLE
Add updo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - [ttop](https://github.com/inv2004/ttop) System monitoring tool with historical data service, triggers and top-like TUI
 - [tufw](https://github.com/peltho/tufw) Terminal UI for ufw
 - [tuicamp](https://github.com/AbeEstrada/tuicamp) Unofficial TimeCamp TUI
+- [updo](https://github.com/Owloops/updo) Website monitoring tool with uptime tracking, response time metrics, and SSL certificate monitoring.
 - [tmd-top](https://github.com/CDWEN0526/tmd-top)   Used to monitor the process tcp traffic of the linux system, detailed to each IP connection
 - [wander](https://github.com/robinovitch61/wander) HashiCorp Nomad terminal client
 - [WTF](https://github.com/senorprogrammer/wtf) The personal information dashboard for your terminal.


### PR DESCRIPTION
Updo is a command-line tool for monitoring website uptime and performance with real-time metrics, multi-region support, and alert notifications.

Repository: https://github.com/Owloops/updo
Created: December 26, 2023
License: MIT

Added to the Dashboards category.