### PR TITLE
Changed the distrobox-tui's link to actively maintained one

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@
 - [diary](https://github.com/actuday6418/Diary) A diary app written in Rust that encrypts both text and file data, and can decrypt and build a rich HTML representation of your diary when required.
 - [DigiSurf](https://github.com/SeanMcLoughlin/digisurf) A TUI signal waveform viewer
 - [diskonaut](https://github.com/imsnif/diskonaut) Terminal disk space navigator
-- [distrobox-tui](https://github.com/hyperreal64/distrobox-tui) TUI for managing distrobox containers
+- [distrobox-tui](https://github.com/phanirithvij/distrobox-tui) TUI for managing distrobox containers
 - [ec2-instance-selector](https://github.com/aws/amazon-ec2-instance-selector) A CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory
 - [emu2](https://github.com/dmsc/emu2) A simple DOS emulator for the Linux text console, supporting basic DOS system calls and console I/O.
 - [flawz](https://github.com/orhun/flawz) A Terminal UI for browsing security vulnerabilities (CVEs)


### PR DESCRIPTION
The currently used link for `distrobox-tui` is pointed towards a repository, archived on May 29, 2024. Its README states that development is being continued on a different repository.

This commit updates the aforementioned link to point to the currently active repository for `distrobox-tui`