### PR TITLE
Wikit (Wiki Kit) WikiJs CLI and TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [vctui](https://github.com/thebsdbox/vctui) Console interface for vCenter
 - [violet](https://github.com/braheezy/violet) Colorful TUI frontend to run Vagrant commands
 - [VT Code](https://github.com/vinhnx/vtcode) VT Code - Semantic Coding Agent
+- [Wikit](https://github.com/BryanCE/wikit) TUI for managing Wiki.js instances
 
 ---
 


### PR DESCRIPTION
Wikit has a CLI and a TUI component built for managing and configuring WikiJs wiki instances. The motivation was to easily handle multiple instances from one place rather than navigating multiple web pages or terminals and also provide the capability to compare features and/or content between sibling instances if needed.

Demo GIF in readme for wikit