### PR TITLE
Add dtop to Docker tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 
 - [Cruise](https://nucleofusion.github.io/cruise/) A Docker TUI Client
 - [ctop](https://github.com/bcicen/ctop) Top-like interface for container metrics
+- [dtop](https://github.com/amir20/dtop) Terminal dashboard for Docker monitoring across multiple hosts
 - [dive](https://github.com/wagoodman/dive) A tool for exploring each layer in a docker image
 - [dockly](https://github.com/lirantal/dockly) Immersive terminal interface for managing docker containers and services
 - [dry](https://github.com/moncho/dry) A Docker manager for the terminal


### PR DESCRIPTION
Hello, 

I am author of dtop and Dozzle. Adding dtop which is a CLI tool I have been working on. It is inspired by ctop which hasn't been maintained.

There are a few requirements for adding new applications to the list.

- Applications should be unique

Not sure if this is true given that `ctop` and `dtop` are similar. `dtop` supports remote hosts and written in Rust for performance. 

- Interfaces should be unique

✅

- Interfaces should be interactive or re-draw output

✅
