### PR TITLE
Add dprs - Docker container management TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@
 - [dtop](https://github.com/amir20/dtop) Terminal dashboard for Docker monitoring across multiple hosts
 - [dive](https://github.com/wagoodman/dive) A tool for exploring each layer in a docker image
 - [dockly](https://github.com/lirantal/dockly) Immersive terminal interface for managing docker containers and services
+- [dprs](https://github.com/durableprogramming/dprs) A TUI for managing Docker containers with real-time monitoring and log streaming
 - [dry](https://github.com/moncho/dry) A Docker manager for the terminal
 - [ducker](https://github.com/robertpsoane/ducker) A slightly quackers Docker TUI based on k9s
 - [e1s](https://github.com/keidarcy/e1s) TUI for managing AWS ECS resources


### PR DESCRIPTION
## Summary
- Add dprs to the Docker/LXC/K8s section

## Description
dprs is a TUI for managing Docker containers with real-time monitoring and log streaming.

Project: https://github.com/durableprogramming/dprs