### PR TITLE
Add Helm minimalistic timer to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@
 - [GeekCalendar](https://github.com/fearlessgeekmedia/GeekCalendar) TUI calendar with vim key bindings, which can import from calcure or calcurse.
 - [Glow](https://github.com/charmbracelet/glow) A markdown reader, designed from the ground up to showcase the elegance and capabilities of TUI.
 - [gocheat](https://github.com/Achno/gocheat) A beautiful TUI cheatsheet for keybindings,hotkeys,gestures and aliases
+- [helm](https://github.com/0xjuanma/helm) A minimalistic & customizable pomodoro-like timer for your terminal
 - [hledger-ui](https://github.com/simonmichael/hledger) A fast TUI for browsing double entry bookkeeping data
 - [h-m-m](https://github.com/nadrad/h-m-m) Hackers Mind Map
 - [hnjobs](https://github.com/mwinters0/hnjobs) Find your next job on Who's Hiring


### PR DESCRIPTION
This MR adds the [helm](https://github.com/0xjuanma/helm) minimal timer. Its a customizable and minimalistic timer for your terminal that helps organize your time, work sessions, interviews, etc.

![helm-demo3](https://github.com/user-attachments/assets/e128a203-403f-47b9-a9b1-0fd928996fa7)
