### PR TITLE
Add sqlit to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [serie](https://github.com/lusingander/serie) A rich git commit graph
 - [soft-serve](https://github.com/charmbracelet/soft-serve) A tasty, self-hostable Git server for the command lineicecream
 - [sot](https://github.com/anistark/sot) A top like system observability tool written in python
+- [sqlit](https://github.com/Maxteabag/sqlit) A lightweight TUI for SQL databases inspired by lazygit
 - [tig](https://github.com/jonas/tig) Text-mode interface for git
 - [vctui](https://github.com/thebsdbox/vctui) Console interface for vCenter
 - [violet](https://github.com/braheezy/violet) Colorful TUI frontend to run Vagrant commands


### PR DESCRIPTION
## Summary

- Adds [sqlit](https://github.com/Maxteabag/sqlit) to the Development section
- 
Fixes #442