### PR TITLE
Add ostui to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@
 - [mpvc](https://github.com/gmt4/mpvc) A mpc-like control interface for mpv
 - [nap](https://nap.sourceforge.net/) Linux napster client
 - [ncspot](https://github.com/hrkfdn/ncspot) Cross-platform ncurses Spotify client written in Rust
+- [ostui](https://git.sr.ht/~ser/ostui) CLI client for Subsonic-API servers like gonic and Navidrome
 - [pyradio](https://github.com/coderholic/pyradio) TUI web radio player with thousands of stations from around the world
 - [RadioGoGo](https://github.com/Zi0P4tch0/RadioGoGo) Go-powered CLI to surf global radio waves via a sleek TUI.
 - [roku-cli](https://github.com/winsbe01/roku-cli) A command line TUI remote for Roku


### PR DESCRIPTION
<!--
Thank you for wanting to contribute to this list! There are many amazing terminal applications and our goal is to provide a place for people to discover them.

There are a few requirements for adding new applications to the list.

- Applications should be unique

    Please don't submit variations of existing applications
- Interfaces should be unique

    Please don't submit output formatters or wrappers (e.g. `fzf`)
- Interfaces should be interactive or re-draw output

    Scripts that accept text prompts are not a good fit for this list
-->
**Package:** `ostui`
**Description:** OpenSubsonic Terminal User Interface, a CLI client for Subsonic-API servers like gonic and Navidrome
**Source-code:** [https://git.sr.ht/~ser/ostui](https://git.sr.ht/~ser/ostui)