### PR TITLE
Add waves - terminal music player with radio mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@
 - [Toutui](https://github.com/AlbanDAVID/Toutui) A TUI Audiobookshelf Client for Linux
 - [upiano](https://github.com/eliasdorneles/upiano) A Piano in your terminal
 - [vlc](https://github.com/videolan/vlc) VLC includes an ncurses interface, `vlc --intf ncurses`
+- [waves](https://github.com/llehouerou/waves) Terminal music player with vim-style navigation and radio mode that plays similar artists from your library
 - [ytui-music](https://github.com/sudipghimire533/ytui-music) Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.
 - [ytdl-tui](https://github.com/darky/ytdl-tui) TUI for downloading Youtube videos
 - [ytfzf](https://github.com/pystardust/ytfzf) A POSIX script that helps you find Youtube videos (without API) or Peertube videos and opens/downloads them using mpv/youtube-dl


### PR DESCRIPTION
Adds [waves](https://github.com/llehouerou/waves) to the Multimedia section.

Waves is a terminal music player built with Go and Bubble Tea featuring:
- Miller column navigation with vim-style keybindings
- SQLite FTS5 for instant full-text search
- Radio mode that uses Last.fm to play similar artists from your own library
- Soulseek integration for downloading with MusicBrainz tagging