### PR TITLE
Add spotatui to Multimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) A sample-based, MIDI-controlled virtual pipe organ instrument compatible with GrandOrgue and Hauptwerk sample sets.
 - [sonicradio](https://github.com/dancnb/sonicradio) A stylish TUI radio player making use of Radio Browser API and Bubbletea.
 - [soundcloud2000](https://github.com/grobie/soundcloud2000) A terminal client for soundcloud
+- [spotatui](https://github.com/LargeModGames/spotatui) Spotify client with native streaming, synced lyrics, and real-time audio visualization
 - [spotify-player](https://github.com/aome510/spotify-player) A Spotify player in the terminal with full feature parity
 - [spotui](https://github.com/ceuk/spotui) Spotify client written in Python
 - [terminal-yt](https://github.com/jooooscha/terminal-yt) A small newsboat-inspired terminal youtube manager


### PR DESCRIPTION
Thank you for wanting to contribute to this list! There are many amazing terminal applications and our goal is to provide a place for people to discover them.

There are a few requirements for adding new applications to the list.

- Applications should be unique

    Please don't submit variations of existing applications
- Interfaces should be unique

    Please don't submit output formatters or wrappers (e.g. `fzf`)
- Interfaces should be interactive or re-draw output

    Scripts that accept text prompts are not a good fit for this list

---

Adding [spotatui](https://github.com/LargeModGames/spotatui) to the Multimedia section.

**Uniqueness:** While there are other Spotify TUIs on this list, there are some differences
- Native audio streaming via librespot (no external player needed)
- Synced lyrics display
- Real-time audio visualization
- Built with Rust and Ratatui

It is a community-maintained continuation of [spotify-tui](https://github.com/Rigellute/spotify-tui) (not on this list), which has been unmaintained since 2021.

**Checklist:**
- [x] Application is unique (features not available in listed alternatives)
- [x] Interface is unique (not a wrapper)
- [x] Interface is interactive (full TUI with keyboard navigation)