### PR TITLE
Add golazo to Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@
 - [gdu](https://github.com/dundee/gdu) Fast disk usage analyzer with console interface written in Go
 - [gif-for-cli](https://github.com/google/gif-for-cli) Convert a gif into ASCII
 - [godap](https://github.com/Macmod/godap) A complete TUI for LDAP written in Golang
+- [golazo](https://github.com/0xjuanma/golazo) Get soccer minute-by-minute updates and finished match stats in your terminal
 - [gpg-tui](https://github.com/orhun/gpg-tui) A terminal user interface for GnuPG
 - [HumBLE Explorer](https://github.com/koenvervloesem/humble-explorer) A cross-platform, command-line and human-friendly Bluetooth Low Energy scanner
 - [IconicFonts](https://github.com/iconicFonts/iconic-fonts) A collection of patched fonts featuring over 60,000 icons, tailored specifically for TUIs.


### PR DESCRIPTION
Golazo is a TUI to get minute-by-minute and finished soccer match stats in your terminal.
https://github.com/0xjuanma/golazo

![golazo-demo](https://github.com/user-attachments/assets/a7e1b381-5b71-4557-a3f4-df7d9b05c9f1)
