### PR TITLE
Add terminal-pong to games

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@
 - [sudoku-rs](https://github.com/MitchelPaulin/sudoku-rs) Sudoku built with tui-rs
 - [sweeper](https://github.com/igor47/sweeper) Minesweeper game using curtsies
 - [terminal-phase](https://gitlab.com/dustyweb/terminal-phase) Space shooter game that runs in your terminal!
+- [terminal-pong](https://github.com/IshmamR/terminal.pong) A simple, fun ping pong game playable entirely in your terminal.
 - [tinytetris](https://github.com/taylorconor/tinytetris) 80x23 terminal tetris!
 - [tty-solitaire](https://github.com/mpereira/tty-solitaire) Solitaire runs in your terminal!
 - [typeinc](https://github.com/AnirudhG07/Typeinc) ncurses based typing speed test with various difficulty levels.


### PR DESCRIPTION
- A fully playable pong game in the terminal.
- Built with Rust and powered by [ratatui](https://crates.io/crates/ratatui) for a beautifully responsive TUI.
- You can play against a basic AI opponent, a friend locally, or just watch AI vs AI in screensaver mode.
- You can choose your favorite color theme and set default difficulty for each mode!

![gif](https://camo.githubusercontent.com/e14409cac274d760ef4637aff7d4e4a26ca35ebb942c03206e1e650389456be9/68747470733a2f2f7668732e636861726d2e73682f7668732d36515867634b5748344335444a7868444275567353712e676966)