### PR TITLE
Add Relax-player - play ambient sounds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@
 - [ncspot](https://github.com/hrkfdn/ncspot) Cross-platform ncurses Spotify client written in Rust
 - [pyradio](https://github.com/coderholic/pyradio) TUI web radio player with thousands of stations from around the world
 - [RadioGoGo](https://github.com/Zi0P4tch0/RadioGoGo) Go-powered CLI to surf global radio waves via a sleek TUI.
+- [Relax-player](https://github.com/ebithril/relax-player) A lightweight, distraction-free alternative to web-based ambient players.
 - [roku-cli](https://github.com/winsbe01/roku-cli) A command line TUI remote for Roku
 - [rmpc](https://mierak.github.io/rmpc/) A configurable MPD client inspired by ncmpcpp and ranger with album art support via various graphics protocols.
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) A sample-based, MIDI-controlled virtual pipe organ instrument compatible with GrandOrgue and Hauptwerk sample sets.


### PR DESCRIPTION
A lightweight, distraction-free alternative to web-based ambient players. Features individual volume control for Rain, Thunder, and Campfire sounds with an alsamixer-style TUI interface.

A lightweight sound mixer with features including multi-sound playback, offline, individual volume control, master volume, mute options, and more, available on Linux, Windows, and macOS.

![gif](https://camo.githubusercontent.com/b1d0dbd656ec9b46362caff64f5a6ed06881782410cc601a194340da9ff7e62e/68747470733a2f2f7668732e636861726d2e73682f7668732d31744974396750533167377a656c4e4435386a53615a2e676966)