### PR TITLE
Add minesweep-rs game

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@
 - [Maze TUI](https://github.com/agl-alexglopez/maze-tui) Build mazes and solve them with various algorithms.
 - [Micro Snake](https://github.com/troglobit/snake) A small snake game, utilizing ANSI escape sequences to draw the board.
 - [Micro Tetris](https://github.com/troglobit/tetris) One of the smallest Tetris implementations in the world, utilizing only ANSI escape sequences to draw the board.
+- [minesweep-rs](https://github.com/cpcloud/minesweep-rs) A mine sweeping game written in Rust using tui-rs.
 - [moon-buggy](https://github.com/seehuhn/moon-buggy) Drive some car across the moon
 - [MyMan](https://sourceforge.net/projects/myman/) MyMan is a video game for color and monochrome text terminals in the genre of Namco's Pac-Man
 - [nchess](https://github.com/billyvinning/nchess) Chess in the terminal, written in C.


### PR DESCRIPTION
This is a minesweeper game which runs in the terminal and built using rust-rs.
It is entirely different from another package on the list [sweeper](https://github.com/igor47/sweeper).

![gif](https://github.com/cpcloud/minesweep-rs/raw/main/demo.gif)