### PR TITLE
Add TUI4J library and Brief chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 - [TermGL](https://github.com/wojciech-graj/TermGL) A terminal-based graphics library for 2D and 3D graphics.
 - [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) Cross-platform terminal UI toolkit for **.NET**
 - [Thermage](https://github.com/thermage/thermage) Thermage is a **PHP** library that provides a fluent and incredibly powerful, object-oriented interface for customizing CLI output text color, background, formatting, theming and more.
+- [TUI4J](https://github.com/WilliamAGH/tui4j) A **Java** terminal UI framework with a Bubble Tea (Go) port and additional features inspired by Textual.
 
 ---
 
@@ -575,6 +576,7 @@
 - [abook](https://abook.sourceforge.io/) TUI addressbook with [mutt](http://www.mutt.org/) integration
 - [awsui](https://github.com/junminhong/awsui) A powerful, user-friendly terminal interface for AWS Profile and SSO management.
 - [Bagels](https://github.com/EnhancedJax/Bagels) TUI expense tracker
+- [Brief](https://github.com/WilliamAGH/brief) Terminal-first OpenAI chat client with slash-command palette and local tool execution.
 - [calcure](https://github.com/anufrievroman/calcure) Modern TUI calendar and task manager with minimal and customizable UI.
 - [calcurse](https://calcurse.org/) calendar and scheduling application for the command line
 - [clipse](https://github.com/savedra1/clipse) TUI-based clipboard manager application


### PR DESCRIPTION
- Adds [TUI4J](https://github.com/WilliamAGH/tui4j) under Libraries → Other (Java terminal UI framework with a Bubble Tea port and Textual‑inspired features)
- Adds [Brief](https://github.com/WilliamAGH/brief) under Productivity (terminal-first OpenAI/ChatGPT chat client with slash‑command palette and local tool execution)

<img width="800" height="632" alt="brief-screenshot" src="https://github.com/user-attachments/assets/396a53e2-40fb-46f8-b568-a5cec058a918" />

Both are interactive TUIs and not listed elsewhere.