### PR TITLE
Add eilmeldung RSS reader to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@
 - [castero](https://github.com/xgi/castero) A TUI app to listen to podcast
 - [CatenaVetus](https://github.com/jimbob88/CatenaVetus) A TUI for reading the Church Fathers
 - [Chawan](https://chawan.net) A TUI web (and (S)FTP, Gopher, Gemini) browser with CSS, inline image and JavaScript support.
+- [eilmeldung](https://github.com/christo-auer/eilmeldung) RSS reader, supporting many RSS providers, bulk-operations and configuration options.
 - [elinks](https://github.com/rkd77/elinks) ELinks (HTTP/FTP/..) brower with mujs javascript support.
 - [hackernews-TUI](https://github.com/aome510/hackernews-TUI) A Terminal UI to browse Hacker News
 - [haxor-news](https://github.com/donnemartin/haxor-news) Browse Hacker News like a haxor: A Hacker News command line interface (CLI)


### PR DESCRIPTION
Added eilmeldung RSS reader to the list of TUI applications.

Thank you for wanting to contribute to this list! There are many amazing terminal applications and our goal is to provide a place for people to discover them.

There are a few requirements for adding new applications to the list.

- Applications should be unique

There are already some TUI RSS readers, though this is my personal spin after many nears of using newsboat.

- Please don't submit variations of existing applications

it's novel

- Please don't submit output formatters or wrappers (e.g. `fzf`)
- Interfaces should be interactive or re-draw output
- Scripts that accept text prompts are not a good fit for this list

<img width="1429" height="894" alt="eilmeldung" src="https://github.com/user-attachments/assets/cca491d7-1388-466d-9b81-bde74d9baaac" />


