### PR TITLE
Add a disk cleanup TUI to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@
 - [keydex](https://github.com/shikaan/keydex) TUI password manager for KeePass databases.
 - [LearnByExample](https://github.com/learnbyexample/TUI-apps) A TUI with tutorials and +300 exercises on python, grep, awk, sed & general terminal usage.
 - [lnav](https://lnav.org/) An advanced log file viewer for the small-scale
+- [mac-cleanup-go](https://github.com/2ykwang/mac-cleanup-go) - macOS disk cleanup TUI: scan cache/dev artifacts, preview, exclude, and move items to Trash.
 - [mapscii](https://github.com/rastapasta/mapscii) Braille & ASCII world map renderer for your console
 - [mqttui](https://github.com/EdJoPaTo/mqttui) MQTT Client written in rust
 - [moc](https://moc.daper.net/download) console audio player


### PR DESCRIPTION
Add [mac-cleanup-go](https://github.com/2ykwang/mac-cleanup-go) under Miscellaneous. It’s a macOS cleanup TUI that scans common caches/dev artifacts, lets you preview and exclude paths, then moves selected items to Trash.
