### PR TITLE
Add lazymake to Development list

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
+- [lazymake](https://github.com/rshelekhov/lazymake) Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.
 - [lazysql](https://github.com/jorgerojas26/lazysql) A cross-platform TUI database management tool written in Go.
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering
 - [LogLens](https://github.com/Caelrith/loglens-core) - A structured log viewer and query engine for the terminal.


### PR DESCRIPTION
Hi there! Would like to add my app for managing targets in makefiles – [Lazymake](https://github.com/rshelekhov/lazymake)

![hero](https://github.com/user-attachments/assets/c66ed0e4-0755-4d97-b28c-a2caa3fba9eb)
