### PR TITLE
Add DockMate to Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@
 - [dtop](https://github.com/amir20/dtop) Terminal dashboard for Docker monitoring across multiple hosts
 - [dive](https://github.com/wagoodman/dive) A tool for exploring each layer in a docker image
 - [dockly](https://github.com/lirantal/dockly) Immersive terminal interface for managing docker containers and services
+- [DockMate](https://github.com/shubh-io/dockmate) A lightweight TUI manager for Docker and Podman
 - [dprs](https://github.com/durableprogramming/dprs) A TUI for managing Docker containers with real-time monitoring and log streaming
 - [dry](https://github.com/moncho/dry) A Docker manager for the terminal
 - [ducker](https://github.com/robertpsoane/ducker) A slightly quackers Docker TUI based on k9s


### PR DESCRIPTION
### Adds [DockMate](https://github.com/shubh-io/dockmate) to the [Docker Section](https://github.com/rothgar/awesome-tuis?tab=readme-ov-file#dockerlxck8s) TUIs list.

<img width="1265" height="766" alt="{00819930-2513-4701-BFB6-C2E56F113FD9}" src="https://github.com/user-attachments/assets/aae0179b-6a22-40a6-9638-ee981a3f3497" />
