### PR TITLE
Add casciian to Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@
 - [xtd](https://github.com/gammasoft71/xtd) Free open-source modern **C++** framework to create console (CLI), forms (GUI like WinForms) and unit test (xUnit) applications and libraries on Windows, macOS, Linux, iOS, Android, FreeBSD, and Haiku.
 
 <h3>Java</h3>
-- [casciian](https://github.com/crramirez/casciian) A Text User Interface Library for **Java** based on "Jexer" without the AWT/Swing dependencies, tailored for GraalVM AOT native compilation with a focus on performance over remote connections and maximum terminal compatibility
+- [casciian](https://github.com/crramirez/casciian) A Text User Interface Library for **Java** based on "Jexer" without the AWT/Swing dependencies, tailored for GraalVM AOT native compilation with a focus on performance over remote connections and maximum terminal compatibility.
 - [Jexer](https://gitlab.com/AutumnMeowMeow/jexer) A **Java** library implements a text-based windowing system loosely reminiscent of Borland's Turbo Vision system.
 - [Lanterna](https://github.com/mabe02/lanterna) A **Java** library for creating text-based UIs, very similar to the C library curses but with more functionality.
 - [TUI4J](https://github.com/WilliamAGH/tui4j) A **Java** terminal UI framework with a Bubble Tea (Go) port and additional features inspired by Textual.


### PR DESCRIPTION
This pull request updates the `README.md` to improve the organization and clarity of the list of Text User Interface (TUI) libraries by introducing a dedicated section for Java libraries. Several Java TUI libraries that were previously listed elsewhere are now grouped together, and a new library is added to the list.

**Documentation organization improvements:**

* Added a new `<h3>Java</h3>` section to group Java TUI libraries together for better discoverability.
* Moved `Jexer`, `Lanterna`, and `TUI4J` from the general list to the new Java section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R365-R370) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L381-L382) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L392)

**Content updates:**

* Added `casciian`, a Text User Interface Library for Java focused on GraalVM AOT native compilation and terminal compatibility, to the new Java section.