### PR TITLE
Add lazycap to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
+- [lazycap](https://github.com/icarus-itcs/lazycap) Terminal dashboard for Capacitor mobile development with device management, builds, live reload, and debugging tools.
 - [lazymake](https://github.com/rshelekhov/lazymake) Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.
 - [lazysql](https://github.com/jorgerojas26/lazysql) A cross-platform TUI database management tool written in Go.
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering


### PR DESCRIPTION
Hi! I'd like to add [lazycap](https://github.com/icarus-itcs/lazycap) to the Development section.

**lazycap** is a terminal dashboard for Capacitor mobile development (iOS/Android) that provides:

- Device management (iOS simulators, Android emulators, physical devices)
- One-key actions for build, sync, run, and open in IDE
- Live reload with external host detection
- 30+ debug/cleanup actions (clear Derived Data, Gradle cache, node_modules, etc.)
- Process monitoring with real-time logs
- AI assistant integration via MCP (Model Context Protocol)
- Firebase Emulator integration
- Plugin system for extensibility

Built with Go using Bubble Tea. Open source (MIT + Commons Clause).

Thanks for considering!