### PR TITLE
Add deputui

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [dblab](https://github.com/danvergara/dblab) The database client every command line junkie deserves
 - [ddqa](https://github.com/DataDog/ddqa) Jira TUI to help with software releases
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output
+- [deputui](https://github.com/twiddler/deputui) Review and install NPM package updates
 - [Feluda](https://github.com/anistark/feluda) Detect restrictive and incompatible licesenses in all dependencies of your project.
 - [Froggit](https://github.com/thewizardshell/froggit) Minimalist Git TUI with GitHub CLI integration
 - [euporie](https://github.com/joouha/euporie) Jupyter notebooks in the terminal


### PR DESCRIPTION
[deputui](https://github.com/twiddler/deputui) is a TUI for reviewing release notes of NPM dependencies. Releases can be selected and printed to stdout, e.g. to install them with one's package manager of choice.

Please refer to its [README.md](https://github.com/twiddler/deputui/blob/main/README.md) for more details.

<img width="1271" height="1049" alt="image" src="https://github.com/user-attachments/assets/83058c0a-e2e3-4e93-9679-9dda1640ec12" />