### PR TITLE
Add ddv

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [dbee](https://github.com/murat-cileli/dbee) Fast & Minimalistic Database Browser
 - [dblab](https://github.com/danvergara/dblab) The database client every command line junkie deserves
 - [ddqa](https://github.com/DataDog/ddqa) Jira TUI to help with software releases
+- [ddv](https://github.com/lusingander/ddv) Terminal DynamoDB viewer
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output
 - [Feluda](https://github.com/anistark/feluda) Detect restrictive and incompatible licesenses in all dependencies of your project.
 - [Froggit](https://github.com/thewizardshell/froggit) Minimalist Git TUI with GitHub CLI integration


### PR DESCRIPTION
DDV is a TUI application to view Amazon DynamoDB in the terminal.

![demo](https://github.com/user-attachments/assets/9e3790e6-70c8-4206-a0d2-5bd40ff9ccce)
