### PR TITLE
Add mdr - markdown renderer, editor, and linter TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [LazySSH](https://github.com/adembc/lazyssh) - TUI SSH manager to browse, connect, and manage servers from ssh config files.
 - [levite](https://github.com/RauliL/levite) A TUI spreadsheet application that uses an RPN formulas and features a vi-friendly interface
 - [mcfly](https://github.com/cantino/mcfly) Intelligent context-aware search engine for your shell history
-- [mdr](https://github.com/tirthpatell/mdr) A markdown renderer, editor, and linter for the terminal with a TUI viewer and live-preview editor
+- [mdr](https://github.com/tirthpatell/mdr) A markdown renderer, editor, and linter for the terminal with a TUI viewer and side-by-side live-preview editor
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management for terminal environments
 - [multranslate](https://github.com/Lifailon/multranslate) A TUI for translating text in multiple translators simultaneously, with support for translation history and language detection
 - [numr](https://github.com/nasedkinpv/numr) A natural language calculator with unit/currency conversions and vim-style keybindings


### PR DESCRIPTION
Adding [mdr](https://github.com/tirthpatell/mdr) to the Productivity section.

**mdr** is a terminal-based markdown tool that provides:
- A TUI viewer with scrollable rendered output (powered by glamour/bubbletea)
- A live-preview editor with side-by-side raw markdown and rendered output
- A structural linter for markdown files

Install: `brew install tirthpatell/tap/mdr` or `go install github.com/tirthpatell/mdr@latest`