### PR TITLE
Add gitlogue to Screensavers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Screensavers</h2></summary>
 
 - [astroterm](https://github.com/da-luce/astroterm) A planetarium for your terminal! Explore stars, planets, constellations, and more
+- [gitlogue](https://github.com/unhappychoice/gitlogue) A TUI screensaver that visualizes Git commit history in your terminal
 - [neo](https://github.com/st3w/neo) Simulates the digital rain from "The Matrix"
 - [rxpipes](https://github.com/inunix3/rxpipes) 2D recreation of the ancient Pipes screensaver for terminals.
 - [pond](https://gitlab.com/alice-lefebvre/pond) A soothing in-terminal idle screen that simulates a little pond.


### PR DESCRIPTION
## Summary

Add [gitlogue](https://github.com/unhappychoice/gitlogue) to the Screensavers section.

gitlogue is a TUI screensaver that visualizes Git commit history in your terminal. It's built with Rust and ratatui.

- Added in alphabetical order between `astroterm` and `neo`