### PR TITLE
Add vortix to Miscellaneous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [tweakcc](https://github.com/Piebald-AI/tweakcc) TUI to customize your Claude Code themes, thinking verbs, and more.
 - [typtea](https://github.com/ashish0kumar/typtea) Minimal terminal-based typing speed tester with support for dozens of programming languages.
 - [try-rs](https://github.com/tassiovirginio/try-rs/) A lightning-fast TUI to manage temporary projects. Create, explore, and clone repositories instantly without cluttering your system.
-- [vortix](https://github.com/Harry-kp/vortix) Terminal UI for WireGuard and OpenVPN with real-time telemetry, leak detection, and kill switch
+- [vortix](https://github.com/Harry-kp/vortix) Terminal UI for WireGuard and OpenVPN with real-time telemetry, leak detection, and kill switch.
 - [wb](https://github.com/MertGunduz/wb) A TUI vocabulary notebook app for Linux based devices.
 - [wego](https://github.com/schachmat/wego) Weather app
 - [wavemon](https://github.com/uoaerg/wavemon) A wireless device monitoring application


### PR DESCRIPTION
## Add vortix

Adds [vortix](https://github.com/Harry-kp/vortix) to the **Miscellaneous** section.

**vortix** is a Terminal UI for WireGuard and OpenVPN with real-time telemetry, leak detection, and kill switch.

- Entry added in alphabetical order within the Miscellaneous section
- Format matches existing entries in the list