### PR TITLE
Add snav to the Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
+- [snav](https://github.com/oomathias/snav) Interactive symbol finder for codebases with fuzzy search, syntax-highlighted preview, and quick file:line:col jumps.
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3
 - [termdbms](https://github.com/mathaou/termdbms) A TUI for viewing and editing database files.
 - [terraform-tui](https://github.com/idoavrah/terraform-tui) view and interact with Terraform state


### PR DESCRIPTION
## Why

`snav` is an interactive terminal UI for navigating large codebases by symbol, making code exploration and jump-to-location workflows faster for developers.

## What

- Add `snav` under the **Development** section in `README.md` with a concise description matching the list style.

## Checklist

- [x] Application is interactive and TUI-based
- [x] Entry is not an output formatter or wrapper around another interactive command
- [x] Entry appears unique within the list
