### PR TITLE
Add sacha - two-pane AWS TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [Raijin](https://github.com/MasonStooksbury/Raijin) A free, simple weather TUI that pulls data without the need for an API key, account, or subscription
 - [rustnet](https://github.com/domcyrus/rustnet) A cross-platform network monitoring tool with deep packet inspection
 - [s-tui](https://github.com/amanusk/s-tui) CPU stress and monitoring utility
+- [sacha](https://github.com/Sachamama/sacha) A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl
 - [talos linux](https://github.com/siderolabs/talos) A Linux distro with a TUI dashboard for local and remote usage


### PR DESCRIPTION
Add [sacha](https://github.com/Sachamama/sacha) to the Dashboards section.

Sacha is a two-pane AWS TUI for browsing, searching, and managing resources across seven services: CloudWatch Logs, S3, DynamoDB, Lambda, SSM Parameter Store, SQS, and EC2.

Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) in Go.