### PR TITLE
Add dna-claude-analysis to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [csysdig](https://github.com/draios/sysdig) root level Ncurses interface for sysdig, Linux system exploration and troubleshooting tool with first class support for containers
 - [damon](https://github.com/hashicorp/damon) TUI interface for Hashicorp Nomad
 - [dashbrew](https://github.com/rasjonell/dashbrew) TUI dashboard builder that lets you visualize data from scripts and APIs.
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) Terminal-style DNA analysis dashboard with green-on-black Matrix aesthetic for visualizing personal genome data across 17 health and genetics categories.
 - [dolphie](https://github.com/charles-001/dolphie) Your single pane of glass for real-time analytics into MySQL/MariaDB & ProxySQL
 - [framework-tool-tui](https://github.com/grouzen/framework-tool-tui) TUI for controlling and monitoring Framework Computers hardware built in Rust
 - [fubar](https://github.com/irishmaestro/fubar) Formidable Unix Binary Arsenal & Repository. TUI built for gtfobins power users.


### PR DESCRIPTION
## Summary

- Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Dashboards section
- It is a terminal-style DNA analysis dashboard with green-on-black Matrix aesthetic (JetBrains Mono font) for visualizing personal genome data across 17 health and genetics categories
- Entry placed in alphabetical order between `dashbrew` and `dolphie`