### PR TITLE
Add gitcredits

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ggc](https://github.com/bmf-san/ggc) A terminal-based Git CLI tool written in Go
 - [gitui](https://github.com/extrawurst/gitui) blazing fast terminal-ui for git written in rust
 - [git-crecord](https://github.com/andrewshadura/git-crecord) interactive selective commit tool
+- [gitcredits](https://github.com/Higangssh/gitcredits) Roll movie-style end credits for any git repo in your terminal
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal


### PR DESCRIPTION
Add [gitcredits](https://github.com/Higangssh/gitcredits) — a CLI tool that rolls movie-style end credits for any git repo in the terminal.

Built with Go + Bubble Tea + Lip Gloss.