### PR TITLE
Add CastLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ani-l](https://github.com/komposer-aml/ani-l) Rust-based anime browsing and streaming all without leaving the terminal
 - [asak](https://github.com/chaosprint/asak) A cross-platform audio recording/playback TUI
 - [bookokrat](https://github.com/bugzmanov/bookokrat) Full-featured EPUB books reader with Vim keybindings.
+- [castlocal](https://github.com/YuriKovalov22/cast-control) Cast local video files to Chromecast with automatic transcoding via CLI/TUI.
 - [chafa](https://hpjansson.org/chafa/) A powerful utility that converts image data, including animated GIFs, into graphics formats or ANSI/Unicode character art suitable for display in a terminal.
 - [cmdpxl](https://github.com/knosmos/cmdpxl) Totally practical command-line image editor
 - [cmus](https://cmus.github.io/) A small, fast and powerful console music player for Unix-like operating systems.


### PR DESCRIPTION
## Add CastLocal

- [castlocal](https://github.com/YuriKovalov22/cast-control) Cast local video files to Chromecast with automatic transcoding via CLI/TUI.

### Why it's awesome

CastLocal is a dual-pane Far Manager-style TUI for casting local video files to Chromecast devices. It auto-discovers devices on the network, probes video formats, and transcodes on-the-fly using ffmpeg with HLS segmentation so playback starts in seconds.

- **Interactive TUI**: Keyboard-driven dual-pane interface — left pane browses files, right pane shows discovered devices
- **Unique**: No other TUI exists for Chromecast casting
- **Redraws output**: Real-time transcode progress and playback controls

Install: `pipx install castlocal`

### Checklist

- [x] Application is unique (no existing TUI for Chromecast casting)
- [x] Interface is interactive and redraws output
- [x] Added in correct alphabetical order in the Multimedia section