### PR TITLE
Add lazylogcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
+- [lazylogcat](https://github.com/parfenovvs/lazylogcat) A TUI to view Android logs from adb logcat
 - [lazymake](https://github.com/rshelekhov/lazymake) Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.
 - [lazysql](https://github.com/jorgerojas26/lazysql) A cross-platform TUI database management tool written in Go.
 - [lazyjournal](https://github.com/Lifailon/lazyjournal) TUI for journalctl, file system logs, as well Docker and Podman containers for quick viewing and filtering


### PR DESCRIPTION
**lazylogcat** is a TUI for viewing (and interacting with) Android adb logcat logs as an alternative to Android Studio's GUI option.

Features:
- Opencode-like keybindings
- Package, tag and text filters with regex support
- Many display options to satisfy visual preferences
- Vi-like visual mode with ability to open selected lines in your default editor
- JSON config support to save user and project level presets

https://github.com/parfenovvs/lazylogcat 