### PR TITLE
Add wiremix

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [upiano](https://github.com/eliasdorneles/upiano) A Piano in your terminal
 - [vlc](https://github.com/videolan/vlc) VLC includes an ncurses interface, `vlc --intf ncurses`
 - [waves](https://github.com/llehouerou/waves) Terminal music player with vim-style navigation and radio mode that plays similar artists from your library
+- [wiremix](https://github.com/tsowell/wiremix) TUI audio mixer for PipeWire similar to pavucontrol to adjust volumes, change input/output devices and their profiles
 - [xytz](https://github.com/xdagiz/xytz) - Beautiful TUI for downloading YouTube videos/playlists/channels.
 - [ytui-music](https://github.com/sudipghimire533/ytui-music) Listen to music from youtube. Configurable, minimal, lightweight, private & beautiful music client.
 - [ytdl-tui](https://github.com/darky/ytdl-tui) TUI for downloading Youtube videos


### PR DESCRIPTION
An audio mixer TUI for PipeWire replicating the functionality of PulsAudio GUIs like pavucontrol or TUIs like ncpamixer.

https://github.com/tsowell/wiremix

Allows changing application <-> device mapping, default input/output devices, individual application/device volumes and audio device profile switching.