### PR TITLE
Add TBunny to Dashboards: A fast, keyboard-driven TUI for managing RabbitMQ clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl
 - [talos linux](https://github.com/siderolabs/talos) A Linux distro with a TUI dashboard for local and remote usage
+- [TBunny](https://github.com/anadale/tbunny) A fast, keyboard-driven TUI for managing RabbitMQ clusters
 - [tdash](https://github.com/jessfraz/tdash) A terminal dashboard with stats from Google Analytics, GitHub, Travis CI, and Jenkins. Very much built specific to me
 - [tegratop](https://github.com/pythops/tegratop) Monitoring tool (top like) for Nvidia jetson boards
 - [TermUI](https://github.com/gizak/termui) Golang terminal dashboard


### PR DESCRIPTION
## Add TBunny

Adds [TBunny](https://github.com/anadale/tbunny) — a fast, keyboard-driven terminal UI 
for managing RabbitMQ clusters, written in Go.

### What it does
- Multi-cluster support — switch between RabbitMQ clusters without leaving the terminal
- Comprehensive views: queues, exchanges, virtual hosts, users, connections, individual messages
- Fully keyboard-driven
- Available via Homebrew (macOS, Linux) and binary releases for Linux/macOS/Windows