### PR TITLE
Add onWatch to Dashboards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nethogs](https://github.com/raboof/nethogs) 'net top' tool
 - [netscanner](https://github.com/Chleba/netscanner) Network scanner
 - [nvtop](https://github.com/Syllo/nvtop) GPUs process monitoring for AMD, Intel and NVIDIA
+- [onWatch](https://github.com/onllm-dev/onwatch) A lightweight CLI and TUI dashboard for tracking AI API quota usage across 7 providers
 - [oryx](https://github.com/pythops/oryx) A TUI for sniffing network traffic using eBPF
 - [otel-tui](https://github.com/ymtdzzz/otel-tui) A terminal OpenTelemetry viewer
 - [Planor](https://github.com/mrusme/planor) The Cloud Aviator, dashboard for AWS, Vultr, Heroku, ...


### PR DESCRIPTION
## Summary

- Adds [onWatch](https://github.com/onllm-dev/onwatch) to the Dashboards section in alphabetical order (between nvtop and oryx)
- onWatch is an open-source Go CLI and TUI dashboard for tracking AI API quota usage across 7 providers (Anthropic, Codex, Synthetic, Z.ai, GitHub Copilot, MiniMax, Antigravity)
- Lightweight (~15MB binary, <50MB RAM), local-first with SQLite storage, zero telemetry, GPL-3.0 licensed
- 342+ GitHub stars

## Entry format

Matches existing list format: `- [Name](repo-url) Short description`