### PR TITLE
Add llm.log to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [kmon](https://github.com/orhun/kmon) Linux Kernel Manager and Activity Monitor
 - [Kyanos](https://github.com/hengyoush/kyanos) Linux network analysis tool based on eBPF
 - [ls-horizons](https://github.com/litescript/ls-horizons) Terminal UI for visualizing NASA's Deep Space Network in real-time
-- [llm.log](https://github.com/lanesket/llm.log) A TUI dashboard for monitoring LLM API calls — token usage, costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary.
+- [llm.log](https://github.com/lanesket/llm.log) A local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary.
 - [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
 - [nerdlog](https://github.com/dimonomid/nerdlog) fast, remote-first, multi-host TUI log viewer
 - [nethogs](https://github.com/raboof/nethogs) 'net top' tool


### PR DESCRIPTION
## What

Adds [llm.log](https://github.com/lanesket/llm.log) to the Dashboards section.

## Description

llm.log is a TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and a full request inspector. Works as a local MITM proxy, so it captures everything with zero code changes. Supports OpenAI, Anthropic and OpenRouter. Single binary, pure Go.

- GitHub: https://github.com/lanesket/llm.log