### PR TITLE
Add stonks-cli to Dashboards section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [sacha](https://github.com/Sachamama/sacha) A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [ServerHub](https://github.com/nickprotop/ServerHub) A TUI server monitoring dashboard for Linux with real-time metrics, scriptable widgets, and remote management
+- [stonks-cli](https://github.com/igoropaniuk/stonks-cli) A terminal-based investment portfolio tracker with live market prices, unrealized P&L, and multi-currency support
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl
 - [talos linux](https://github.com/siderolabs/talos) A Linux distro with a TUI dashboard for local and remote usage
 - [tdash](https://github.com/jessfraz/tdash) A terminal dashboard with stats from Google Analytics, GitHub, Travis CI, and Jenkins. Very much built specific to me


### PR DESCRIPTION
Add stonks-cli to the Dashboards section in alphabetical order.

Why it qualifies per the contribution guidelines:

- Unique application - not a variation of existing entries. While `ticker` shows live prices and `portfolio_rs` is a non-interactive CLI, stonks-cli is a full interactive TUI with portfolio CRUD operations (add/edit/remove positions and cash), multi-currency forex conversion, watchlists, and extended-hours quote support.
- Interactive interface ` keyboard-driven navigation, clickable sort headers, focus switching between panels, and inline editing dialogs. It redraws in real-time with configurable refresh intervals.
- Not a wrapper ` standalone Python application fetching data directly from Yahoo Finance, no API key required.


![demo](https://github.com/igoropaniuk/stonks-cli/raw/main/docs/assets/demo.gif)

