### PR TITLE
Add lazyenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows
+- [lazyenv](https://github.com/lazynop/lazyenv) - TUI for managing .env files, with side-by-side diff, completeness matrix, secret masking, and 56 color themes. Written in Go with Bubble Tea.
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
 - [lazymake](https://github.com/rshelekhov/lazymake) Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.
 - [lazysql](https://github.com/jorgerojas26/lazysql) A cross-platform TUI database management tool written in Go.
@@ -783,3 +784,4 @@ There's a lot of cool projects here that I have no association with. Run them at
 ---
 
 </details>
+


### PR DESCRIPTION
Add [lazyenv](https://github.com/lazynop/lazyenv) to the Development section.

lazyenv is a TUI for managing `.env` files, built with Bubble Tea (Go). It features side-by-side diff, a completeness matrix for comparing keys across multiple files, secret masking, and 56 color themes.

It fits the requirements:
- Unique application (no other .env file manager in the list)
- Interactive TUI (not a wrapper or output formatter)
- Actively maintained