### PR TITLE
Add passtui

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,11 +431,8 @@ There's a lot of cool projects here that I have no association with. Run them at
   stateful TUI apps, complete with extensions known as [bubbles](https://github.com/charmbracelet/bubbles)
 - [gum](https://github.com/charmbracelet/gum) A tool for glamorous **shell** scripts
 - [ink](https://github.com/vadimdemedes/ink) React for **Node.js** interactive command-line apps
-<<<<<<< add-ink-web
 - [ink-web](https://github.com/cjroth/ink-web) A browser-based runtime for Ink that renders React TUI apps in the browser using xterm.js.
-=======
 - [Melker](https://melker.sh) A HTML-like, document-first TUI framework for **TypeScript/Deno** with permission sandboxing, flexbox layout, and run-from-URL support.
->>>>>>> main
 - [moulti](https://moulti.run/) A CLI-driven TUI displaying arbitrary outputs inside visual, collapsible blocks. Designed with **shell** scripts in mind. **Ansible**-friendly too.
 - [nimwave](https://github.com/ansiwave/nimwave) Build text interfaces for the terminal or browser in **Nim**
 - [nocterm](https://github.com/Norbert515/nocterm) A Flutter-like TUI framework for **Dart** with hot reload, 45+ components, and declarative UI patterns.
@@ -541,6 +538,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [oha](https://github.com/hatoo/oha) HTTP load generator
 - [packemon](https://github.com/ddddddO/packemon) Packet generator and monitor.
 - [pass-cli](https://github.com/arimxyer/pass-cli) A TUI and CLI password manager with rclone cloud syncing support
+- [passtui](https://github.com/fjmoralesp/passtui) The terminal user interface for [pass](https://www.passwordstore.org/), the standard unix password manager
 - [PesterExplorer](https://github.com/HeyItsGilbert/PesterExplorer) A TUI to explore Pester results.
 - [pug](https://github.com/leg100/pug) terraform and tofu module and infrastructure management.
 - [profanity](https://github.com/profanity-im/profanity) A cross-platfrom XMPP client.


### PR DESCRIPTION
PassTUI is a terminal user interface for [pass](https://www.passwordstore.org/) — the standard Unix password manager. It brings a keyboard-driven, visual experience to your encrypted password store without ever leaving the terminal.

If you live in the terminal and want a fast, intuitive way to manage your GPG-encrypted passwords, PassTUI is for you.

Repository: https://github.com/fjmoralesp/passtui

<img width="800" alt="passtui" src="https://github.com/user-attachments/assets/ee2e56e4-e185-4425-9b6d-ccf589960ef2" />
