### PR TITLE
Add cruise TUI to Docker/LXC/K8s section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Docker/LXC/K8s</h2></summary>
 
 - [Argonaut](https://github.com/darksworm/argonaut) ArgoCD TUI
+- [cruise](https://github.com/cruise-org/cruise) A container management TUI
 - [ctop](https://github.com/bcicen/ctop) Top-like interface for container metrics
 - [d4s](https://github.com/jr-k/d4s) A fast, keyboard-driven terminal UI to manage Docker containers, Compose stacks, and Swarm services with the ergonomics of K9s
 - [dtop](https://github.com/amir20/dtop) Terminal dashboard for Docker monitoring across multiple hosts


### PR DESCRIPTION
Re-adding cruise, for a while the link was broken, since I had migrated off of a personal repository to a dedicated org.
https://github.com/cruise-org/cruise
The link should remain working now, since I dont plan on changes.

The description has been changed from 'A Docker TUI Client' to 'A Container management TUI` to accommodate changes currently in dev that would expand the support of cruise from just docker, to containers, registries and much more in the future. 