### PR TITLE
Add killpy to File Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [adbtuifm](https://github.com/darkhz/adbtuifm) A TUI file manager for Android, based on the Android Debug Bridge(ADB).
 - [broot](https://github.com/Canop/broot) A new way to see and navigate directory trees
 - [deletor](https://github.com/pashkov256/deletor) Manage and delete files efficiently with an interactive TUI and scriptable CLI.
+- [killpy](https://github.com/Tlaloc-Es/killpy) A TUI for scanning and cleaning Python environments, caches, and build artifacts across all major toolchains (venv, Poetry, Conda, pipx, pyenv, uv and more)
 - [far2l](https://github.com/elfmz/far2l) Linux port of Far v2 file manager
 - [fml](https://github.com/wick3dr0se/fml) :file_folder: A stupid simple, fast file manager written in BASH v4.2+.
 - [goful](https://github.com/anmitsu/goful) a powerful TUI file manager written in Go.


### PR DESCRIPTION
Added killpy to File Managers

killpy is a TUI for scanning and cleaning Python environments and build artifacts across all major toolchains (venv, Poetry, Conda, pipx, pyenv, uv, Hatch, tox). Built with Textual, it streams results asynchronously as detectors finish, supports sorting, regex filtering, and multi-select deletion. Also includes a scriptable CLI for automation.

There's nothing else in the list that does Python-specific environment cleanup — the closest is mac-cleanup-go but it's macOS-only and generalist.

Repo: https://github.com/Tlaloc-Es/killpy
Active since 2023, 37 releases, MIT license