### PR TITLE
Add cautom and aether

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,12 +295,14 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Games</h2></summary>
 
 - [tui-2048](https://github.com/ps06756/tui-2048) The game 2048 for your terminal
+- [Aether](https://github.com/BitPeppr/Aether) Boids in your terminal! Highly customisable and infinitely amusing, with predators and alluring targets.
 - [awkaster](https://github.com/TheMozg/awk-raycaster) Pseudo-3D shooter written completely in gawk using raycasting technique
 - [balatrotui](https://github.com/Passeriform/BalatroTUI) A TUI clone of Balatro
 - [bastet](https://github.com/fph/bastet) Evil falling block game
 - [botany](https://github.com/jifunks/botany/) Virtual plant buddy
 - [brickgame-4bit](https://github.com/ilyakurdyukov/brickgame-4bit) Brick Game emulator (4-bit Holtek chip)
 - [BrogueCE](https://github.com/tmewett/BrogueCE) Beautiful roguelike dungeon crawler
+- [Cautom](https://github.com/BitPeppr/Cellular-automaton) A highly customisable cellular automaton visualiser for the terminal.
 - [cbonsai](https://gitlab.com/jallbrit/cbonsai) A bonsai tree generator
 - [chess-tui](https://github.com/thomas-mauran/chess-tui) Play Chess in your terminal, built in rust
 - [clidle](https://github.com/ajeetdsouza/clidle) Play Wordle in your terminal. Also works over SSH!


### PR DESCRIPTION
Add Aether and Cautom to the game section.

Aether and Cautom are cool visualisations (boids – with predators, alluring targets, and more – and cellular automaton – coloured visualisations, custom rules, and more – respectively) for the terminal, written in python by hand. They are both highly customisable, with extensive CLI flags that allow control over every element of the simulation. 

Hope you like them! If there are any feature suggestions or any general advice I would love to implement them in the future.

Github links:
Aether: https://github.com/BitPeppr/Aether
Cautom: https://github.com/BitPeppr/Cellular-automaton