### PR TITLE
Add unifly to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ttop](https://github.com/inv2004/ttop) System monitoring tool with historical data service, triggers and top-like TUI
 - [tufw](https://github.com/peltho/tufw) Terminal UI for ufw
 - [tuicamp](https://github.com/AbeEstrada/tuicamp) Unofficial TimeCamp TUI
+- [unifly](https://github.com/hyperb1iss/unifly) CLI and TUI for managing Ubiquiti UniFi network infrastructure with live traffic charts, topology, and firewall policy management
 - [updo](https://github.com/Owloops/updo) Website monitoring tool with uptime tracking, response time metrics, and SSL certificate monitoring.
 - [tmd-top](https://github.com/CDWEN0526/tmd-top) Used to monitor the process tcp traffic of the linux system, detailed to each IP connection
 - [wander](https://github.com/robinovitch61/wander) HashiCorp Nomad terminal client


### PR DESCRIPTION
[unifly](https://github.com/hyperb1iss/unifly) is a Rust CLI and TUI for managing Ubiquiti UniFi network infrastructure.

The TUI ships an 8-screen dashboard (live WAN traffic charts, devices, clients, networks, firewall, topology, events, stats) built with Ratatui. It unifies the UniFi Integration API and Legacy API into a single coherent interface.

- Repo: https://github.com/hyperb1iss/unifly
- License: Apache-2.0

Entry added alphabetically to the Dashboards section.