### PR TITLE
Add snips.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
+- [snips.sh](https://github.com/robherley/snips.sh) ✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3
 - [termdbms](https://github.com/mathaou/termdbms) A TUI for viewing and editing database files.
 - [terraform-tui](https://github.com/idoavrah/terraform-tui) view and interact with Terraform state


### PR DESCRIPTION
Adding **snips.sh** to Development since the closest tool to it is Nap, in that section.

Snips.sh is a pastebin which works over SSH.

To run:
```bash
ssh snips.sh
```

![img](https://vhs.charm.sh/vhs-1MRS4DCN6XUpxzM2PrqCfL.gif)

- Homepage: https://snips.sh
- Repo: https://github.com/robherley/snips.sh
