### PR TITLE
Add resume-cli to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [rainfrog](https://github.com/achristmascarl/rainfrog) A database management TUI for Postgres, MySQL, and SQLite written in Rust
 - [regex-tui](https://github.com/vitor-mariano/regex-tui) A simple TUI to visualize and test regular expressions
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
+- [resume-cli](https://github.com/inevolin/resume-cli) CLI for resuming AI coding sessions across Claude Code, Codex, and GitHub Copilot. Lists recent sessions in one place and relaunches the one you pick in whichever tool you choose.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3


### PR DESCRIPTION
**[resume-cli](https://github.com/inevolin/resume-cli)** is a CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot. Pick a session and continue it in whichever tool you want — useful when hitting a usage limit mid-session and needing to switch tools.

Added alphabetically in the Development section between `resterm` and `runme`.