### PR TITLE
Add prt to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [otel-tui](https://github.com/ymtdzzz/otel-tui) A terminal OpenTelemetry viewer
 - [Planor](https://github.com/mrusme/planor) The Cloud Aviator, dashboard for AWS, Vultr, Heroku, ...
 - [process-compose](https://github.com/F1bonacc1/process-compose) TUI for running apps and processes
+- [prt](https://github.com/rekurt/prt) Real-time network port monitoring with change tracking, alerts, process trees, and firewall integration
 - [psmux](https://github.com/marlocarlo/psmux) tmux-compatible terminal multiplexer for Windows built in Rust with ratatui.
 - [psnet](https://github.com/marlocarlo/psnet) Real-time TUI network monitor for Windows with speed graphs, DNS resolution, and packet inspection.
 - [pstop](https://github.com/marlocarlo/pstop) htop-style system monitor for Windows with per-core CPU bars, tree view, and 7 color schemes.


### PR DESCRIPTION
## Description

[prt](https://github.com/rekurt/prt) is a real-time terminal UI for monitoring network ports — an interactive alternative to `lsof -i` / `ss -tlnp`.

**Key features:**
- Live auto-refreshing table with change tracking (new connections = green, closed = red)
- Known ports database (170+ services), suspicious connection detection
- Container awareness (Docker/Podman), bandwidth monitoring
- Firewall quick-block, strace/dtruss attach, SSH tunnel creation
- Alert rules via TOML config, process tree visualization
- NDJSON streaming and watch mode for scripting
- Multilingual (EN, RU, ZH), cross-platform (macOS + Linux)

Built with Rust (ratatui + crossterm). Install: `cargo install prt`

**Similar tools already in the list:** bandwhich, nethogs, netscanner, oryx — prt complements these as a comprehensive port-focused monitoring TUI.