### PR TITLE
Add nylas under Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nomadnet](https://github.com/markqvist/NomadNet) Secure messaging network built on Reticulum
 - [nostui](https://github.com/akiomik/nostui) Nostr client
 - [nostratui](https://github.com/adamm-xyz/nostratui) A terminal user interface (TUI) for browsing Nostr posts, written in Rust.
+- [nylas](https://github.com/nylas/cli) Email and calendar TUI for Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP through one auth flow. Run with `nylas tui`.
 - [Profanity](https://profanity-im.github.io) XMPP (Jabber) client
 - [sclack](https://github.com/haskellcamargo/sclack) Slack terminal client
 - [scli](https://github.com/isamert/scli/) A simple terminal user interface for signal messenger


### PR DESCRIPTION
Adds `nylas` to the Messaging section, alphabetically between `nostratui` and `Profanity`.

**What it is:** Email and calendar TUI for Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. Run with `nylas tui`. Sits alongside aerc, alpine, matcha, meli, Mutt, and sup.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com
**Install:** `brew install nylas/nylas-cli/nylas`