### PR TITLE
Add ctop - AI coding agent session monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [cheatshh](https://github.com/AnirudhG07/cheatshh) A fzf TUI for managing custom made command-line cheatsheet for Unix.
 - [claws](https://github.com/clawscli/claws) A terminal UI for AWS resource management with vim-style keybindings, command-mode navigation, and optional read-only mode.
 - [cointop](https://github.com/miguelmota/cointop) The fastest and most interactive terminal based UI application for tracking cryptocurrencies
+- [ctop](https://github.com/aakashadesara/ctop) Monitor AI coding agent sessions (Claude Code, Codex CLI). Context windows, tokens, costs, CPU/memory.
 - [CoreFreq](https://github.com/cyring/CoreFreq) CPU monitoring software designed for the 64-bits Processors
 - [csysdig](https://github.com/draios/sysdig) root level Ncurses interface for sysdig, Linux system exploration and troubleshooting tool with first class support for containers
 - [damon](https://github.com/hashicorp/damon) TUI interface for Hashicorp Nomad


### PR DESCRIPTION
Adds [ctop](https://github.com/aakashadesara/ctop) to the list.

- **What**: Terminal UI for monitoring AI coding agent sessions (Claude Code, Codex CLI)
- **Features**: Context window tracking, token usage, cost estimates, CPU/memory, live log tailing
- **Maintained**: Yes, actively developed
- **Interactive**: Yes (vim keybindings, mouse, multiple views)