### PR TITLE
Add Dodo Payments CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output
 - [deputui](https://github.com/twiddler/deputui) Review and install NPM package updates
 - [differ](https://github.com/JanSmrcka/differ) A TUI git diff viewer
+- [dodopayments-cli](https://github.com/dodopayments/dodopayments-cli) An interactive TUI for managing payments, subscriptions and webhooks on Dodo Payments, with a built-in AI assistant.
 - [euporie](https://github.com/joouha/euporie) Jupyter notebooks in the terminal
 - [fast-resume](https://github.com/angristan/fast-resume) Index and fuzzy search coding agent sessions
 - [Feluda](https://github.com/anistark/feluda) Detect restrictive and incompatible licesenses in all dependencies of your project.


### PR DESCRIPTION
Adding [Dodo Payments CLI](https://github.com/dodopayments/dodopayments-cli) to the **Development** section (alphabetically between `differ` and `euporie`).

A maintained, interactive TUI for managing Dodo Payments resources (payments, subscriptions, customers, products, webhooks) from your terminal. Built on @opentui/solid (TypeScript/Solid.js). Features a command palette, history, live notifications, a built-in AI assistant via MCP, and webhook tooling (live listen + offline trigger).

- Repo: https://github.com/dodopayments/dodopayments-cli
- License: GPL-3.0