### PR TITLE
Add hnr - terminal UI for Hacker News

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [elinks](https://github.com/rkd77/elinks) ELinks (HTTP/FTP/..) brower with mujs javascript support.
 - [hackernews-TUI](https://github.com/aome510/hackernews-TUI) A Terminal UI to browse Hacker News
 - [haxor-news](https://github.com/donnemartin/haxor-news) Browse Hacker News like a haxor: A Hacker News command line interface (CLI)
+- [hnr](https://github.com/prasanthj/hnr) A terminal UI for Hacker News — browse feeds, read threaded comments, vote, reply, search, and bookmark
 - [Lagrange](https://gmi.skyjake.fi/lagrange) Lagrange is a cross-platform client for browsing Geminispace
 - [LYNX](https://lynx.invisible-island.net/) A text based Terminal browser
 - [podliner](https://github.com/timkicker/podliner) A cross-platform podcast client


### PR DESCRIPTION
## Description

Adds [h.n.r](https://github.com/prasanthj/hnr) (say it as "honor"), a terminal UI for Hacker News built in Rust.

**Features:**
- Six feeds: Top, New, Best, Ask HN, Show HN, Jobs
- Threaded comments with inline expand/collapse
- Comment prefetch — comments fetched automatically after a short dwell; pane switches without pressing Enter
- Reader mode — fetches and renders articles as structured text (headings, code blocks, quotes, lists) with section navigation
- Animated shimmer progress indicator for all async operations (feed refresh, article fetch, comment prefetch, search)
- Algolia-powered search
- Voting, replies, bookmarks, seen tracking
- User profiles, clipboard copy, browser open
- Login/session persistence

**Install:**
```bash
brew tap prasanthj/hnr && brew install hnr
# or
cargo install hnr
```

![h.n.r showcase](https://github.com/prasanthj/hnr/blob/main/showcase.gif?raw=true)