### PR TITLE
Add scout

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ranger](https://github.com/ranger/ranger) A VIM-inspired file manager for the console.
 - [rovr](https://github.com/NSPC911/rovr) A post-modern terminal file manager.
 - [s3duck-tui](https://github.com/nexusriot/s3duck-tui) A TUI S3 client.
+- [scout](https://github.com/mirageglobe/scout) A dual-pane terminal file manager with git status badges and syntax-highlighted previews.
 - [sfm](https://github.com/afify/sfm) Simple file manager.
 - [superfile](https://github.com/MHNightCat/superfile) Pretty fancy and modern terminal file manager.
 - [TUIFIManager](https://github.com/GiorgosXou/TUIFIManager) A cross-platform terminal-based file manager _(supports termux)_.


### PR DESCRIPTION
[scout](https://github.com/mirageglobe/scout) is a dual-pane terminal file manager written in Go.

- single binary, zero config, works on any machine
- dual-pane layout: file explorer + syntax-highlighted preview side by side
- git status badges (modified, staged, untracked) visible at a glance
- time-aware color themes, keyboard-driven navigation
- installable via homebrew: `brew install mirageglobe/tap/scout`

added to the **File Managers** section in alphabetical order.