### PR TITLE
Add OpenSeek - TUI coding agent (TS/Bun, DeepSeek V4 native) to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nap](https://github.com/maaslalani/nap) Code snippets in your terminal
 - [nodebro](https://github.com/jonaburg/nodebro) Easily view most recent Github releases/tags and release notes from the terminal
 - [opencode](https://github.com/sst/opencode) AI coding agent, built for the terminal
+- [OpenSeek](https://github.com/LichAmnesia/openseek) TUI coding agent in TypeScript/Bun with native DeepSeek V4 backend, real-time prefix cache hit rate display, real MCP client, LSP feedback loop, and 27 providers
 - [opcilloscope](https://github.com/SquareWaveSystems/opcilloscope) OPC UA client TUI with real-time oscilloscope view for industrial automation
 - [Quorum](https://github.com/Detrol/quorum-cli) Multi-agent AI discussion system for structured debates between LLMs
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq


### PR DESCRIPTION
Adds [OpenSeek](https://github.com/LichAmnesia/openseek) to the **Development** section, placed after `opencode` since both are AI coding agents.

OpenSeek is an open-source TUI coding agent built in TypeScript/Bun monorepo. v1.0 shipped with 56/56 SPEC gates closed, 954 tests passing, 1.4MB bundle, Apache-2.0.

Key features:
- Native DeepSeek V4 backend with real-time prefix cache hit rate display in cost meter
- Real MCP client + server (stdio + SSE + websocket transports, handrolled JSON-RPC 2.0)
- LSP feedback loop across 5 languages (tsserver / rust-analyzer / pyright / gopls / clangd)
- 27 providers (OpenAI-compat, Anthropic, Bedrock, Vertex, Azure, custom)
- Plan / Agent / YOLO modes with git worktree isolation

Install: `npm install -g openseek` (requires `bun >= 1.3`)

Repo: https://github.com/LichAmnesia/openseek