### PR TITLE
feat: add longbridge-terminal (AI-native financial markets CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [khal](https://github.com/pimutils/khal) A standards based CLI calendar program, able to synchronize with CalDAV servers
 - [LazySSH](https://github.com/adembc/lazyssh) TUI SSH manager to browse, connect, and manage servers from ssh config files.
 - [levite](https://github.com/RauliL/levite) A TUI spreadsheet application that uses an RPN formulas and features a vi-friendly interface
+- [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) AI-native TUI for Longbridge Securities: real-time quotes, portfolio management, and trading for HK/US/A-share/SG markets.
 - [mcfly](https://github.com/cantino/mcfly) Intelligent context-aware search engine for your shell history
 - [mynav](https://github.com/GianlucaP106/mynav) Workspace and session management for terminal environments
 - [multranslate](https://github.com/Lifailon/multranslate) A TUI for translating text in multiple translators simultaneously, with support for translation history and language detection


### PR DESCRIPTION
## Description

Add [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) to the **Productivity** section.

## What is longbridge-terminal?

An AI-native TUI for Longbridge Securities built in Rust. It provides real-time market data, portfolio management, and trading for HK / US / A-share / SG markets.

- **Language**: Rust (ratatui TUI)
- **Stars**: 837+
- **Repo**: https://github.com/longbridge/longbridge-terminal

## Checklist

- [x] Added in alphabetical order within the Productivity section
- [x] Description is concise and accurate
- [x] Link is correct and points to the GitHub repo
- [x] Tool is maintained and interactive (TUI)