### PR TITLE
Add pixtuoid to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nvtop](https://github.com/Syllo/nvtop) GPUs process monitoring for AMD, Intel and NVIDIA
 - [oryx](https://github.com/pythops/oryx) A TUI for sniffing network traffic using eBPF
 - [otel-tui](https://github.com/ymtdzzz/otel-tui) A terminal OpenTelemetry viewer
+- [pixtuoid](https://github.com/IvanWng97/pixtuoid) Terminal pixel-art dashboard for multiple Claude Code agents — half-block sprites, per-tool monitor glow, multi-floor office.
 - [Planor](https://github.com/mrusme/planor) The Cloud Aviator, dashboard for AWS, Vultr, Heroku, ...
 - [process-compose](https://github.com/F1bonacc1/process-compose) TUI for running apps and processes
 - [psmux](https://github.com/marlocarlo/psmux) tmux-compatible terminal multiplexer for Windows built in Rust with ratatui.


### PR DESCRIPTION
Adds [pixtuoid](https://github.com/IvanWng97/pixtuoid) to **Dashboards** (alphabetical insert between \`otel-tui\` and \`Planor\`).

### What it is

A terminal pixel-art dashboard for multiple AI coding agents — each running Claude Code session shows up as an animated half-block sprite in a top-down coworking office. Monitor glow per tool call, A*-routed walking, multi-floor overflow, weather effects, themes.

Built in Rust on ratatui + crossterm + tokio. Half-block rendering for ~2× vertical resolution. macOS-first, but works over SSH.

### Eligibility

- ⭐ 83 stars, MIT licensed
- Published to crates.io
- v0.4.1 shipped today
- Active CI (rustfmt, clippy, cargo-deny, tests, codecov)
![image](https://github.com/user-attachments/assets/ed29fbe4-3670-4487-b516-67f1751beb6a)