### PR TITLE
Add quokka: iPhone inspection TUI for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nemu](https://github.com/nemuTUI/nemu) A TUI for QEMU
 - [recoverpy](https://github.com/PabloLec/recoverpy) A TUI to recover overwritten or deleted data.
 - [rocket.term](https://github.com/gerstner-hub/rocket.term) Text based chat client for the Rocket.chat messaging solution.
+- [quokka](https://github.com/dutradotdev/quokka) TUI launcher for iPhone inspection and cleanup over USB. macOS, no jailbreak.
 - [smassh](https://github.com/kraanzu/smassh) A TUI based typing test application inspired by MonkeyType.
 - [steam_friends_list_tui](https://github.com/AdamWHY2K/steam_friends_list_tui) The steam friends list in the commandline
 - [Systemd-manager-tui](https://github.com/matheus-git/systemd-manager-tui) A program for managing systemd services through a TUI.


### PR DESCRIPTION
Adding quokka to the Miscellaneous section.

https://github.com/dutradotdev/quokka

macOS CLI/TUI for inspecting and cleaning up iPhones over USB. Ships a TUI launcher and log viewer. Uses usbmuxd + Apple lockdown, no jailbreak required.

Requirements check:
- Repo is active and has been public since early 2025
- - Application is unique (no other iPhone inspection TUI exists on this list)
- - Interface is interactive (TUI launcher, log viewer, interactive device inspector)
- - Not a wrapper around other TUIs
Written in Rust. MIT license.