### PR TITLE
Add pisesh - pi coding-agent session bookmark/resume TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support
 - [pkm](https://github.com/wick3dr0se/pkm) A super minimal TUI package manager wrapper written in BASH v4.2+
 - [pomo](https://github.com/Bahaaio/pomo) A minimal, customizable TUI Pomodoro timer with ASCII art, progress bar, desktop notifications, and productivity statistics. 
+- [pisesh](https://github.com/Blue-B/pisesh) Bookmark, search, and resume pi coding-agent sessions with a fast keyboard-driven TUI
 - [portfolio_rs](https://github.com/MarkusZoppelt/portfolio_rs) A command line tool for managing financial investment portfolios.
 - [pream-team](https://github.com/nikoladucak/pream-team/) a TUI utility that helps you keep track of your teams GitHub PRs across multiple repositories
 - [presenterm](https://github.com/mfontanini/presenterm) A markdown terminal slideshow tool


### PR DESCRIPTION
[**pisesh**](https://github.com/Blue-B/pisesh) is a single-file zero-dependency Node TUI that adds favorites, search, and a `[NOW]` badge to the [pi coding-agent](https://github.com/earendil-works/pi) session resume picker.

Sits naturally in `## Productivity` next to `agent-deck` (Terminal dashboard for managing multiple AI coding agent sessions) and `mynav` (Workspace and session management for terminal environments).

- npm: https://www.npmjs.com/package/pisesh
- MIT licensed
- CJK-aware width math
- Alt-screen buffer (terminal restored on exit, like vim/less/htop)