### PR TITLE
Add hcom to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
+- [hcom](https://github.com/aannoo/hcom) CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows


### PR DESCRIPTION
Adds [hcom](https://github.com/aannoo/hcom) to the Development section.

hcom is a CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals. Agents can message each other mid-turn, observe transcripts and live terminal screens, subscribe to events, and spawn or fork each other. Single Rust binary, SQLite-backed. MIT, 318 ⭐, first commit July 2025.