### PR TITLE
Add 'patent' tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [opencode](https://github.com/sst/opencode) AI coding agent, built for the terminal
 - [opcilloscope](https://github.com/SquareWaveSystems/opcilloscope) OPC UA client TUI with real-time oscilloscope view for industrial automation
 - [Quorum](https://github.com/Detrol/quorum-cli) Multi-agent AI discussion system for structured debates between LLMs
+- [patent](https://github.com/r14dd/patent) Prior-art search for your code ideas — checks 11 package registries with local semantic ranking and an Ollama verdict.
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq
 - [posting](https://github.com/darrenburns/posting) A powerful HTTP client that lives in your terminal
 - [pproftui](https://github.com/Oloruntobi1/pproftui) A terminal-based UI for Go's pprof that makes profiling interactive


### PR DESCRIPTION
Adds patent, a ratatui TUI that searches 11 registries to check whether a dev-tool idea already exists — local fastembed ranking + an Ollama verdict. Published on crates.io.
