### PR TITLE
Add 'patent' tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [opencode](https://github.com/sst/opencode) AI coding agent, built for the terminal
 - [opcilloscope](https://github.com/SquareWaveSystems/opcilloscope) OPC UA client TUI with real-time oscilloscope view for industrial automation
 - [Quorum](https://github.com/Detrol/quorum-cli) Multi-agent AI discussion system for structured debates between LLMs
+- [patent](https://github.com/r14dd/patent) A prior-art search for your code ideas. Stop building what already exists.
 - [play](https://github.com/paololazzari/play) A TUI playground to experiment with your favorite programs, such as grep, sed, awk, jq and yq
 - [posting](https://github.com/darrenburns/posting) A powerful HTTP client that lives in your terminal
 - [pproftui](https://github.com/Oloruntobi1/pproftui) A terminal-based UI for Go's pprof that makes profiling interactive


### PR DESCRIPTION
Added a new tool 'patent' for prior-art search in code ideas.
