### PR TITLE
Add dotty to File Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [adbtuifm](https://github.com/darkhz/adbtuifm) A TUI file manager for Android, based on the Android Debug Bridge(ADB).
 - [broot](https://github.com/Canop/broot) A new way to see and navigate directory trees
 - [deletor](https://github.com/pashkov256/deletor) Manage and delete files efficiently with an interactive TUI and scriptable CLI.
+- [dotty](https://github.com/RiccardoCataldi/dotty) Terminal dashboard to browse and preview dotfiles in ~ with expandable tree, fuzzy search, and live preview
 - [far2l](https://github.com/elfmz/far2l) Linux port of Far v2 file manager
 - [fml](https://github.com/wick3dr0se/fml) :file_folder: A stupid simple, fast file manager written in BASH v4.2+.
 - [goful](https://github.com/anmitsu/goful) a powerful TUI file manager written in Go.


### PR DESCRIPTION
Adds [dotty](https://github.com/RiccardoCataldi/dotty) to the File Managers section.

dotty is a TUI for browsing dotfiles in your home directory from any working directory. It scans `~` for dot entries, shows an expandable tree with live file preview, and includes a fuzzy finder (`/`) to jump to configs quickly. Built with Go and Bubble Tea. Single static binary, zero config, MIT licensed.

Similar tools in this list (yazi, lf, broot) are general-purpose file managers. dotty is scoped to dotfiles only — a unified view of `.aws`, `.ssh`, `.config`, etc. without navigating the full filesystem.