### PR TITLE
Add Agent CLI Menu to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) Launch and resume Claude Code / Codex sessions — frecency project launcher with full-transcript fuzzy session search
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
Adds [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) to the **Development** section, placed alphabetically between `act3` and `amtui`.

It's a genuine TUI (built on ink): a frecency-sorted project launcher and a full-transcript fuzzy search over your past Claude Code / Codex sessions with an inline transcript peek — not just a wrapper around another interactive command. MIT, macOS, `brew install --cask roypadina/tap/agentclimenu`.

Disclosure: I'm the author. Entry matches the section's one-line format and alphabetical order.