### PR TITLE
Add microNeo to Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [maki](https://sr.ht/~bscit/maki/) A simple tabbed text editor with file navigation and an emphasis on preserving battery life
 - [markln](https://github.com/xqtr/markln) A terminal-based markdown editor built with Textual.
 - [micro](https://github.com/zyedidia/micro) A modern and intuitive terminal-based text editor
+- [microNeo](https://github.com/sollawen/microNeo) A fork of Micro with in-place Markdown rendering — view and edit in the same window
 - [nino](https://github.com/evanlin96069/nino) A small terminal-based text editor written in C.
 - [orbiton](https://github.com/xyproto/orbiton) Text editor limited by VT100, suitable for programming, writing git commit messages and editing Markdown
 - [slap](https://github.com/slap-editor/slap) Sublime-like terminal-based text editor


### PR DESCRIPTION
microNeo is a fork of Micro that adds in-place Markdown rendering — open a .md file and see it rendered immediately, click anywhere to edit. No split panes.

It is the only terminal editor that renders and edits Markdown in the same window. Similar tools like Glow/frogmouth are viewers (read-only), and other Markdown editors use split panes. microNeo does both in one view.

Built in Go, single binary, one-line install.

https://github.com/sollawen/microNeo

Thanks!