### PR TITLE
Add dos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [damon](https://github.com/hashicorp/damon) TUI interface for Hashicorp Nomad
 - [dashbrew](https://github.com/rasjonell/dashbrew) TUI dashboard builder that lets you visualize data from scripts and APIs.
 - [dolphie](https://github.com/charles-001/dolphie) Your single pane of glass for real-time analytics into MySQL/MariaDB & ProxySQL
+- [dos](https://github.com/anthony-chaudhary/dos-kernel) A fleet watchdog for AI coding agents: live what's-running dashboard (dos top) and what-needs-a-human queue (dos decisions), with verdicts from git evidence rather than agent self-reports
 - [framework-tool-tui](https://github.com/grouzen/framework-tool-tui) TUI for controlling and monitoring Framework Computers hardware built in Rust
 - [fubar](https://github.com/irishmaestro/fubar) Formidable Unix Binary Arsenal & Repository. TUI built for gtfobins power users.
 - [gh-dash](https://github.com/dlvhdr/gh-dash) A rich terminal UI for GitHub PRs and Issues


### PR DESCRIPTION
Adds [dos](https://github.com/anthony-chaudhary/dos-kernel) to Dashboards (alphabetical slot, one line).

dos is an open-source (MIT, Python) trust kernel for fleets of AI coding agents; its TUIs are `dos top` — a live what's-running-now fleet dashboard (which runs are advancing vs stalled, from git/journal deltas) — and `dos decisions`, the what-needs-a-human queue. Interactive, maintained, installable with `pip install dos-kernel[tui]`.