### PR TITLE
add hwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [Grafterm](https://github.com/slok/grafterm) Metrics dashboards on terminal, a Grafana inspired terminal version
 - [htop](https://github.com/htop-dev/htop) Interactive text-mode process viewer for Unix systems. It aims to be a better 'top'
 - [htui](https://github.com/PierreKieffer/htui) Heroku Terminal User Interface
+- [hwatch](https://github.com/blacknon/hwatch) A modern alternative to watch that records command output history and provides interactive diff views, scrolling, filtering, JSON logging, and hooks.
 - [hwinfo-tui](https://github.com/JuanjoFuchs/hwinfo-tui) A gping-inspired terminal visualization tool for monitoring real-time hardware sensor data from HWInfo
 - [ID-Spoofer](https://github.com/NubleX/ID-Spoofer) A cross-platform cybersecurity toolkit for fingerprint and traffic obfuscation.
 - [kaskade](https://github.com/sauljabin/kaskade) TUI for kafka, which allows you to interact and consume topics from your terminal in style!


### PR DESCRIPTION
add hwatch to dashboard.

hwatch is a modern interactive alternative to `watch`. It repeatedly runs a command, records command output history, and provides an interactive TUI for browsing history, viewing diffs, scrolling output, filtering, using custom keymaps, JSON logging, and hooks.