### PR TITLE
Add Servonaut to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [sacha](https://github.com/Sachamama/sacha) A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [ServerHub](https://github.com/nickprotop/ServerHub) A TUI server monitoring dashboard for Linux with real-time metrics, scriptable widgets, and remote management
+- [Servonaut](https://github.com/zb-ss/servonaut) A TUI for managing AWS, Hetzner, OVH and custom SSH servers with log viewing, CloudWatch/CloudTrail browsing, IP banning, AI log analysis and a built-in MCP server
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl
 - [talos linux](https://github.com/siderolabs/talos) A Linux distro with a TUI dashboard for local and remote usage
 - [tdash](https://github.com/jessfraz/tdash) A terminal dashboard with stats from Google Analytics, GitHub, Travis CI, and Jenkins. Very much built specific to me


### PR DESCRIPTION
Adds [Servonaut](https://github.com/zb-ss/servonaut) — a TUI for managing servers across AWS EC2, Hetzner, OVH and custom SSH hosts: SSH/SCP, remote file browsing, log viewing, CloudWatch/CloudTrail browsing, IP banning (WAF/SG/NACL), AI log analysis, and a built-in MCP server for AI agents.

Python/Textual, MIT licensed, on PyPI (`pipx install servonaut`), actively maintained. Placed in **Dashboards** alongside comparable tools (Planor, sacha, ServerHub).