### PR TITLE
Add Sifty to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nemu](https://github.com/nemuTUI/nemu) A TUI for QEMU
 - [recoverpy](https://github.com/PabloLec/recoverpy) A TUI to recover overwritten or deleted data.
 - [rocket.term](https://github.com/gerstner-hub/rocket.term) Text based chat client for the Rocket.chat messaging solution.
+- [Sifty](https://github.com/Vortrix5/sifty) A safety-first Windows maintenance TUI: clean junk, analyze disk usage, find duplicate files, and manage apps, updates and startup programs, with every change previewed first and deletions sent to the Recycle Bin.
 - [smassh](https://github.com/kraanzu/smassh) A TUI based typing test application inspired by MonkeyType.
 - [steam_friends_list_tui](https://github.com/AdamWHY2K/steam_friends_list_tui) The steam friends list in the commandline
 - [Systemd-manager-tui](https://github.com/matheus-git/systemd-manager-tui) A program for managing systemd services through a TUI.


### PR DESCRIPTION
Adding Sifty, an open-source Windows maintenance tool I built that runs as a full-screen TUI (built with Textual).

`sifty tui` opens an interactive app with sections for cleaning junk, disk usage analysis, duplicate finding, and managing apps, updates and startup programs. Findings come with inline action buttons to fix them on the spot, and there is a command palette (Ctrl+P) plus bulk row selection for batch actions. It is close in spirit to mac-cleanup-go that is already on this list, but for Windows.

Everything previews before it acts and deletions go to the Recycle Bin, so it is hard to break something by accident.

- Added under **Miscellaneous** in alphabetical order (before smassh)
- Followed the existing entry format

Repo: https://github.com/Vortrix5/sifty
