### PR TITLE
Add hash to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
+- [hash](https://github.com/tfcace/hash) An AI-native POSIX shell; type ?? to drive any ACP agent inline
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows


### PR DESCRIPTION
Adds [hash](https://github.com/tfcace/hash), an open-source POSIX shell (Go, MIT) with a Bubble Tea TUI. Typing `??` anywhere on the command line opens an inline turn against any ACP agent (Claude Code, Gemini CLI): natural-language command generation, piping output into the agent, and single-flag completion. Placed alphabetically in Development.