### PR TITLE
Add lazyslurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [kaskade](https://github.com/sauljabin/kaskade) TUI for kafka, which allows you to interact and consume topics from your terminal in style!
 - [kmon](https://github.com/orhun/kmon) Linux Kernel Manager and Activity Monitor
 - [Kyanos](https://github.com/hengyoush/kyanos) Linux network analysis tool based on eBPF
+- [lazyslurm](https://github.com/hill/lazyslurm) A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
 - [ls-horizons](https://github.com/litescript/ls-horizons) Terminal UI for visualizing NASA's Deep Space Network in real-time
 - [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
 - [nerdlog](https://github.com/dimonomid/nerdlog) fast, remote-first, multi-host TUI log viewer


### PR DESCRIPTION
Adds lazyslurm to the Dashboards section.

A lazygit-style terminal UI for the Slurm workload manager, built with ratatui. It monitors jobs, tails logs, and shows node and partition state.

- Repo is older than 6 months (created September 2025)
- Interactive TUI that redraws live, not a wrapper or output formatter
- Unique: no other Slurm dashboard currently in the list

![lazyslurm demo](https://github.com/hill/lazyslurm/raw/master/media/demo.gif)
