### PR TITLE
Add dlt-tui to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output
 - [deputui](https://github.com/twiddler/deputui) Review and install NPM package updates
 - [differ](https://github.com/JanSmrcka/differ) A TUI git diff viewer
+- [dlt-tui](https://github.com/tkmsikd/dlt-tui) A fast, keyboard-centric viewer for Automotive DLT (AUTOSAR Diagnostic Log and Trace) files with regex search, compound filters, and live dlt-daemon streaming
 - [euporie](https://github.com/joouha/euporie) Jupyter notebooks in the terminal
 - [fast-resume](https://github.com/angristan/fast-resume) Index and fuzzy search coding agent sessions
 - [Feluda](https://github.com/anistark/feluda) Detect restrictive and incompatible licesenses in all dependencies of your project.


### PR DESCRIPTION
Adds [dlt-tui](https://github.com/tkmsikd/dlt-tui), a fast keyboard-centric TUI viewer for Automotive DLT (AUTOSAR Diagnostic Log and Trace) files.

- Regex search + compound filters (level / APP ID / CTX ID)
- Unified multi-file timeline, .gz/.zip support, hex dump detail view
- Live TCP streaming from a running dlt-daemon
- Written in Rust (ratatui), MIT licensed, prebuilt binaries available

Inserted in alphabetical order in the Development section.