### PR TITLE
Add dockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [dockly](https://github.com/lirantal/dockly) Immersive terminal interface for managing docker containers and services
 - [DockMate](https://github.com/shubh-io/dockmate) A lightweight TUI manager for Docker and Podman
 - [docker-dash](https://github.com/GustavoCaso/docker-dash) A full TUI managemnet tool for Docker
+- [dockup](https://github.com/paulo-amaral/dockup) One-command TUI to install, harden and maintain Docker, Podman, NVIDIA toolkit and Apple container
 - [dprs](https://github.com/durableprogramming/dprs) A TUI for managing Docker containers with real-time monitoring and log streaming
 - [dry](https://github.com/moncho/dry) A Docker manager for the terminal
 - [ducker](https://github.com/robertpsoane/ducker) A slightly quackers Docker TUI based on k9s


### PR DESCRIPTION
Adds [dockup](https://github.com/paulo-amaral/dockup) to Docker/LXC/K8s.

One-command TUI (Go/Bubble Tea, MIT) to install, harden and maintain Docker Engine + Compose v2, Podman, NVIDIA Container Toolkit and Apple's container tool, including a read-only CIS-inspired security audit. Demo GIF in the README is auto-generated with VHS.