### PR TITLE
Add svy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [sacha](https://github.com/Sachamama/sacha) A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.
 - [sockttop](https://github.com/jasonwitty/socktop) socktop is a remote system monitor with a rich TUI, inspired by top/btop, talking to a lightweight agent over WebSockets.
 - [ServerHub](https://github.com/nickprotop/ServerHub) A TUI server monitoring dashboard for Linux with real-time metrics, scriptable widgets, and remote management
+- [svy](https://github.com/svy-tui/svy) Interactive viewer for sar/sysstat historical data — like btop, but for the past
 - [sysz](https://github.com/joehillen/sysz) An fzf terminal UI for systemctl
 - [talos linux](https://github.com/siderolabs/talos) A Linux distro with a TUI dashboard for local and remote usage
 - [tdash](https://github.com/jessfraz/tdash) A terminal dashboard with stats from Google Analytics, GitHub, Travis CI, and Jenkins. Very much built specific to me


### PR DESCRIPTION
Adds [svy](https://github.com/svy-tui/svy) to **Dashboards** (alphabetical order, between ServerHub and sysz).

svy is an interactive terminal viewer for sar/sysstat historical data — braille charts with a time cursor, zoom, day-by-day browsing, and per-CPU/NIC/disk instance switching. It reads `sadf -j` JSON (no binary sa parsing) and can pull remote data over ssh, so you can browse a server's performance history from your laptop. MIT, published on npm (`npx @svy-tui/svy --demo` for a synthetic-data demo).