### PR TITLE
Add otaku to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nless](https://github.com/mpryor/nothing-less) Terminal pager for exploring tabular data with vi keybindings and automatic delimiter inference
 - [numr](https://github.com/nasedkinpv/numr) A natural language calculator with unit/currency conversions and vim-style keybindings
 - [openmux](https://github.com/monotykamary/openmux) A terminal multiplexer with master-stack layout (Zellij-style)
+- [otaku](https://github.com/enclavum/otaku) A chat client for local LLMs (Ollama, LM Studio, MLX) with encrypted searchable history and cross-provider model management
 - [pagerduty-tui](https://github.com/Mk555/pagerduty-tui) Minimalistic terminal UI to manage triggered incidents
 - [patat](https://github.com/jaspervdj/patat) Terminal-based presentations using Pandoc
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support


### PR DESCRIPTION
Adds [otaku](https://github.com/enclavum/otaku) — a terminal chat client for local LLMs (Ollama, LM Studio, MLX, any OpenAI-compatible server) with full-screen prompt_toolkit pickers (model picker with RAM gauge + load/unload, searchable conversation history), streaming markdown, and AES-256-GCM-encrypted local history. Placed alphabetically in Productivity, next to the other AI chat clients (Brief, elia). MIT, Python 3.11+, actively maintained.