### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [sq](https://github.com/sheenazien8/sq) A database client specially made for vim users
 - [tig](https://github.com/jonas/tig) Text-mode interface for git
 - [turbostream](https://github.com/turboline-ai/turbostream) Tool to extract key signals from high-velocity streaming data using AI Agents
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) Local-first memory lifecycle TUI for AI agents with recall, audit, forgetting, consolidation, and Ratatui.
 - [vctui](https://github.com/thebsdbox/vctui) Console interface for vCenter
 - [violet](https://github.com/braheezy/violet) Colorful TUI frontend to run Vagrant commands
 - [VT Code](https://github.com/vinhnx/vtcode) VT Code - Semantic Coding Agent


### PR DESCRIPTION
## Summary

- Add Tree Ring Memory to the Development section.
- It provides an interactive `tree-ring tui` terminal operator console for local-first AI-agent memory workflows.

## Links

- Project: https://github.com/TerminallyLazy/Tree-Ring-Memory
- Launch page: https://terminallylazy.github.io/Tree-Ring-Memory/

## Checks

- Confirmed there is no existing Tree Ring Memory entry.
- Confirmed the project includes a maintained interactive terminal UI.
- Ran `git diff --check`.
