### PR TITLE
add layerx to Docker/LXC/K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ktop](https://github.com/vladimirvivien/ktop) A top-like tool for your Kubernetes clusters
 - [kubetui](https://github.com/sarub0b0/kubetui) A TUI tool designed for monitoring Kubernetes resources.
 - [lazycontainer](https://github.com/andreybleme/lazycontainer) TUI for managing Apple containers
+- [layerx](https://github.com/deveshpharswan/layerx) Terminal UI for inspecting Docker image layers — view file contents, sort by size, and extract files. Goes further than dive.
 - [lazydocker](https://github.com/jesseduffield/lazydocker) The lazier way to manage everything docker
 - [lazytrivy](https://github.com/owenrumney/lazytrivy) The lazier way to scan images, k8s and the filesytem with Trivy
 - [oxker](https://github.com/mrjackwills/oxker) A simple tui to view & control docker containers

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ktop](https://github.com/vladimirvivien/ktop) A top-like tool for your Kubernetes clusters
 - [kubetui](https://github.com/sarub0b0/kubetui) A TUI tool designed for monitoring Kubernetes resources.
 - [lazycontainer](https://github.com/andreybleme/lazycontainer) TUI for managing Apple containers
-- [layerx](https://github.com/deveshctl/layerx) Terminal UI for inspecting Docker image layers — view file contents, sort by size, and extract files. Goes further than dive.
+- [layerx](https://github.com/deveshctl/layerx) Terminal UI for inspecting Docker image layers — browse layer diffs, view file contents inline, sort by size, and extract files
 - [lazydocker](https://github.com/jesseduffield/lazydocker) The lazier way to manage everything docker
 - [lazytrivy](https://github.com/owenrumney/lazytrivy) The lazier way to scan images, k8s and the filesytem with Trivy
 - [oxker](https://github.com/mrjackwills/oxker) A simple tui to view & control docker containers

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ktop](https://github.com/vladimirvivien/ktop) A top-like tool for your Kubernetes clusters
 - [kubetui](https://github.com/sarub0b0/kubetui) A TUI tool designed for monitoring Kubernetes resources.
 - [lazycontainer](https://github.com/andreybleme/lazycontainer) TUI for managing Apple containers
-- [layerx](https://github.com/deveshpharswan/layerx) Terminal UI for inspecting Docker image layers — view file contents, sort by size, and extract files. Goes further than dive.
+- [layerx](https://github.com/deveshctl/layerx) Terminal UI for inspecting Docker image layers — view file contents, sort by size, and extract files. Goes further than dive.
 - [lazydocker](https://github.com/jesseduffield/lazydocker) The lazier way to manage everything docker
 - [lazytrivy](https://github.com/owenrumney/lazytrivy) The lazier way to scan images, k8s and the filesytem with Trivy
 - [oxker](https://github.com/mrjackwills/oxker) A simple tui to view & control docker containers

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ktop](https://github.com/vladimirvivien/ktop) A top-like tool for your Kubernetes clusters
 - [kubetui](https://github.com/sarub0b0/kubetui) A TUI tool designed for monitoring Kubernetes resources.
 - [lazycontainer](https://github.com/andreybleme/lazycontainer) TUI for managing Apple containers
-- [layerx](https://github.com/deveshctl/layerx) Terminal UI for inspecting Docker image layers — browse layer diffs, view file contents inline, sort by size, and extract files
+- [layerx](https://github.com/deveshctl/layerx) Terminal UI for inspecting container image layers — browse layer diffs, view file contents inline, sort by size, and extract files
 - [lazydocker](https://github.com/jesseduffield/lazydocker) The lazier way to manage everything docker
 - [lazytrivy](https://github.com/owenrumney/lazytrivy) The lazier way to scan images, k8s and the filesytem with Trivy
 - [oxker](https://github.com/mrjackwills/oxker) A simple tui to view & control docker containers


### PR DESCRIPTION
add layerx to Docker/LXC/K8s.

layerx is a terminal UI for inspecting container image layers. Navigate each layer's filesystem diff, view file contents directly in the terminal, and understand exactly what every build step added or removed.

- view file contents inline without leaving the TUI
- extract individual files out of any layer
- sort files by size across the entire image
- works with Docker, Podman, and OCI archives — no daemon needed
- multi-platform image support via --platform flag
- CI mode with pass/fail on efficiency thresholds
- diff two images side by side

Layers panel on the left, live filetree on the right. Files show permissions, uid, and size in a columnar layout. Single static binary, built in Go with bubbletea/lipgloss.

https://github.com/deveshctl/layerx

Thanks for maintaining the list!