### PR TITLE
Add showagent to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [regex-tui](https://github.com/vitor-mariano/regex-tui) A simple TUI to visualize and test regular expressions
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
+- [showagent](https://github.com/aytzey/showagent) Browse, search, resume, branch, and convert local AI coding agent sessions (Claude Code, Codex, Gemini CLI, OpenCode)
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
 - [snips.sh](https://github.com/robherley/snips.sh) ✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3


### PR DESCRIPTION
This adds [showagent](https://github.com/aytzey/showagent), a Go/Bubble Tea TUI that unifies the local session stores of Claude Code, Codex, Gemini CLI, and OpenCode: fuzzy search grouped by workspace, resume via each agent's own CLI, branch local copies, and convert transcripts between agents' native formats. I'm the author of showagent. It is MIT licensed, fully local, and inserted alphabetically in the Development section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)