### PR TITLE
Add scope to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [regex-tui](https://github.com/vitor-mariano/regex-tui) A simple TUI to visualize and test regular expressions
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
+- [scope](https://github.com/matheuswhite/scope-rs) Cross-platform serial-port & RTT monitor with colored timestamped I/O, hex/@tag input macros, search, session recording, auto-reconnect and Lua plugins
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
 - [snips.sh](https://github.com/robherley/snips.sh) ✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3


### PR DESCRIPTION
Adds [scope](https://github.com/matheuswhite/scope-rs) to the **Development** section (inserted alphabetically).

Scope is a cross-platform serial-port and RTT monitor TUI: colored, timestamped send/receive, hex and `@tag` input macros, search, command history, session recording, auto-reconnect, send-file, and Lua plugins. Built with `ratatui`; runs on Linux, Windows and macOS.