### PR TITLE
Add bullmq-dash to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [bottom](https://github.com/ClementTsang/bottom) A customizable graphical process/system monitor for the terminal.
 - [bpytop](https://github.com/aristocratos/bpytop) A Python-based system monitor with lots of information.
 - [btop++](https://github.com/aristocratos/btop) Resource monitor with extras
+- [bullmq-dash](https://github.com/quanghuynt14/bullmq-dash) Dashboard for monitoring BullMQ queues, inspecting jobs, and retrying failures
 - [cgdb](https://github.com/cgdb/cgdb) Console front-end to the GNU debugger
 - [chdig](https://github.com/azat/chdig) Dig into ClickHouse with TUI interface
 - [cheatshh](https://github.com/AnirudhG07/cheatshh) A fzf TUI for managing custom made command-line cheatsheet for Unix.


### PR DESCRIPTION
Adds [bullmq-dash](https://github.com/quanghuynt14/bullmq-dash) — a terminal dashboard for monitoring BullMQ (Redis-backed job queue): live queue/job views, failed-job triage with stacktraces, guarded batch retries, and a `/` search + `Ctrl+P` command palette. MIT licensed, actively maintained (I'm the author). Demo GIF in the repo README.

Inserted alphabetically in the Dashboards section.