### PR TITLE
Add cli.poker to Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [BrogueCE](https://github.com/tmewett/BrogueCE) Beautiful roguelike dungeon crawler
 - [cbonsai](https://gitlab.com/jallbrit/cbonsai) A bonsai tree generator
 - [chess-tui](https://github.com/thomas-mauran/chess-tui) Play Chess in your terminal, built in rust
+- [cli.poker](https://www.cli.poker) Ranked heads-up Texas Hold'em played over SSH. Nothing to install: ssh cli.poker
 - [clidle](https://github.com/ajeetdsouza/clidle) Play Wordle in your terminal. Also works over SSH!
 - [csol](https://github.com/nielssp/csol) Collection of solitaire/patience games, such as Klondike, FreeCell, Spider, and Yukon
 - [DOOM-ASCII](https://github.com/wojciech-graj/doom-ascii) Text-based DOOM running in terminal.


### PR DESCRIPTION
Adds cli.poker, ranked heads-up No-Limit Hold'em played over SSH. Matchmaking pairs you with another online player and rates games with Glicko-2; if nobody shows up within 45 seconds you get a bot.

Demo: https://asciinema.org/a/n0mC6PWjX5hsE7DX

On the requirements:
- Interactive TUI: full game interface with cards, an action log, and table chat. The Games section already has SSH games (sshtron, ssHattrick, clidle).
- Unique: no poker in the list today.
- The link is the project website because this is a hosted service without a public source repo. The list has website-linked entries already (helix, kakoune, irssi, proxymock), so I hope the same works here.
- Repo age: no repo to point at, but the game is live and maintained. Happy to close this if hosted services are out of scope.