### PR TITLE
Add xnano to Python 

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [UniCurses](https://github.com/unicurses/unicurses) A **Python** module that is aimed at providing the Curses functionality on all operating systems.
 - [urwid](https://github.com/urwid/urwid) A console user interface library for **Python** on Linux, OSX, Cygwin or other unix-like OS.
 - [Vindauga](https://github.com/gabbpuy/vindauga) A **Python** implementation of the BSD licensed C++ Turbo Vision library.
+- [xnano](https://github.com/hsaeed3/xnano) A modern, lightweight and declarative **Python** TUI framework built on top of the Rust ratatui and tachyonfx libraries. ([docs](https://xnano.hammad.app))
 
 <h3>GO</h3>
 


### PR DESCRIPTION
## Summary
- Add [xnano](https://github.com/hsaeed3/xnano), a modern, lightweight, and declarative Python TUI framework built on top of the Rust `ratatui` and `tachyonfx` libraries, under the Python Libraries section.
- Docs: https://xnano.hammad.app