### PR TITLE
Add sabiql to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns
 - [scope](https://github.com/matheuswhite/scope-rs) Cross-platform serial-port & RTT monitor with colored timestamped I/O, hex/@tag input macros, search, session recording, auto-reconnect and Lua plugins
+- [sabiql](https://github.com/riii111/sabiql) A fast, driver-less TUI to browse, query, and edit PostgreSQL databases, written in Rust
 - [sls-dev-tools](https://github.com/Theodo-UK/sls-dev-tools) Dev Tools for the Serverless World
 - [snips.sh](https://github.com/robherley/snips.sh) ✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI
 - [stu](https://github.com/lusingander/stu) A TUI for Amazon S3


### PR DESCRIPTION
Adds [sabiql](https://github.com/riii111/sabiql) to the Development section.

sabiql is a fast, driver-less TUI for browsing, querying, and editing PostgreSQL databases. It uses the `psql` CLI and is built with Rust and Ratatui.

This resubmits #575, which was closed because the project had not yet met the six-month age requirement. The repository was created on 2025-12-27 and now meets that requirement.