### PR TITLE
Add gitwig to Development / Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ggc](https://github.com/bmf-san/ggc) A terminal-based Git CLI tool written in Go
 - [ghcup](https://github.com/haskell/ghcup-hs) An installer for the Haskell toolchain
 - [gitui](https://github.com/extrawurst/gitui) blazing fast terminal-ui for git written in rust
+- [gitwig](https://github.com/tareqmy/gitwig) - A mouse-drivable git TUI and multi-repo dashboard built in Rust.
 - [gitv](https://github.com/jayanaxhf/gitv): A beautiful, feature-rich and performant terminal client for GitHub issues.
 - [git-crecord](https://github.com/andrewshadura/git-crecord) interactive selective commit tool
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.


### PR DESCRIPTION
Hi! I'm submitting Gitwig to the `Development / Utilities` section. 

It is a completely custom, interactive terminal client built with Rust and Ratatui that acts as a multi-repo dashboard and includes full mouse-drag support for panel resizing. 

I know the repository is only a month old, but it is an active solo project with 32 releases already under its belt. I would love for you to check it out and see if the quality warrants an exception to the age rule! Thank you for the consideration.