### PR TITLE
Add agentty to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [agentty](https://github.com/1ay1/agentty) A blazing-fast native C++26 coding agent TUI and drop-in claude-code alternative; single static binary, millisecond startup, sandboxed by default, any model (Claude/OpenAI/Groq/OpenRouter/Ollama)
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
Adds **agentty** to the **Development** section, in alphabetical position (between `act3` and `amtui`).

[agentty](https://github.com/1ay1/agentty) is a native **C++26** terminal coding agent — a drop-in claude-code alternative. It's a real TUI (single-function `Model → Element` renderer, no GC pauses mid-stream), ships as one static binary with no runtime deps, cold-starts in under a millisecond, sandboxes shell calls by default, and runs any model (Claude, OpenAI, Groq, OpenRouter, local Ollama). MIT, actively developed.

Format matches the section (`[name](link) description`, alphabetical).