### PR TITLE
Add hawser to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
+- [hawser](https://github.com/Nastwinns/hawser) A k9s-style cockpit to orchestrate reproducible multi-repo git stacks, with cross-repo PR/MR flow. Written in Rust.
 - [hcom](https://github.com/aannoo/hcom) CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq


### PR DESCRIPTION
Adds [hawser](https://github.com/Nastwinns/hawser) under Development.

A k9s-style TUI cockpit to orchestrate reproducible multi-repo git stacks: pins many repos to one lockfile, runs parallel build/test across the fleet, and opens cross-repo PR/MR changesets. Written in Rust.

- TUI built with ratatui (bare `haw` launches the cockpit)
- Docs + interactive course: https://nastwinns.github.io/hawser/
- Entry placed alphabetically between `harlequin` and `hcom`.