### PR TITLE
Add Aether to development TUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [Aether](https://github.com/connectchiragg/aether) Local observability TUI for Claude Code and Codex sessions, including context, tokens, cost, tools, compactions, agents, and code changes
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
## Summary

- add Aether to the Development section
- describe its local observability support for Claude Code and Codex sessions

## Validation

- confirmed Aether is an interactive, maintained terminal UI
- checked the repository link
- ran `git diff --check`
