### PR TITLE
Add binzaar to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.
 - [austin-tui](https://github.com/P403n1x87/austin-tui) The top-like text-based user interface for Austin
+- [binzaar](https://github.com/Techthos/binzaar) A local app store for Go micro-apps — browse a catalog, install SHA-256-verified release binaries, update and uninstall; also drivable by LLMs via an MCP server mode
 - [blinkenlights](https://github.com/jart/blink) TUI that may be used for debugging x86_64-linux or i8086 programs across platforms
 - [brows](https://github.com/rubysolo/brows) CLI GitHub release browser
 - [burf](https://github.com/razeghi71/burf) TUI for Google Cloud Storage (GCS)


### PR DESCRIPTION
Adds [binzaar](https://github.com/Techthos/binzaar) to the Development section.

binzaar is an interactive tview TUI that works as a local app store for Go micro-apps: browse a GitHub-hosted catalog, install SHA-256-verified release binaries for your OS/arch, update, verify, and uninstall — all in one self-contained binary. Actively maintained, latest release v0.7.1.