### PR TITLE
Add leadzaar to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [kanban-python](https://github.com/Zaloog/kanban-python) Kanban Terminal App written in Python
 - [khal](https://github.com/pimutils/khal) A standards based CLI calendar program, able to synchronize with CalDAV servers
 - [LazySSH](https://github.com/adembc/lazyssh) TUI SSH manager to browse, connect, and manage servers from ssh config files.
+- [leadzaar](https://github.com/Techthos/leadzaar) A local-first, single-user sales CRM — leads, contacts, companies and deals in one self-contained Go binary, with an MCP server mode for AI assistants
 - [levite](https://github.com/RauliL/levite) A TUI spreadsheet application that uses an RPN formulas and features a vi-friendly interface
 - [longbridge-terminal](https://github.com/longbridge/longbridge-terminal) AI-native TUI for Longbridge Securities: real-time quotes, portfolio management, and trading for HK/US/A-share/SG markets.
 - [lssh](https://github.com/blacknon/lssh) A terminal-native remote access suite for SSH workflows, including interactive host selection, parallel commands, mux workspaces, file transfer, sync, diff, forwarding, and multi-host monitoring.


### PR DESCRIPTION
Adds [leadzaar](https://github.com/Techthos/leadzaar) to the Productivity section.

leadzaar is a local-first, single-user sales CRM with an interactive tview TUI: leads, contacts, companies and deals in one self-contained Go binary backed by an embedded bbolt file — no server, no network. Actively maintained, latest release v0.9.0.