### PR TITLE
Add herdr

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [Glow](https://github.com/charmbracelet/glow) A markdown reader, designed from the ground up to showcase the elegance and capabilities of TUI.
 - [gocheat](https://github.com/Achno/gocheat) A beautiful TUI cheatsheet for keybindings,hotkeys,gestures and aliases
 - [helm](https://github.com/0xjuanma/helm) A minimalistic & customizable pomodoro-like timer for your terminal
+- [herdr](https://github.com/ogulcancelik/herdr) A terminal multiplexer and workspace manager for AI coding agents, organizing terminals into workspaces, tabs, and panes
 - [hledger-ui](https://github.com/simonmichael/hledger) A fast TUI for browsing double entry bookkeeping data
 - [h-m-m](https://github.com/nadrad/h-m-m) Hackers Mind Map
 - [hnjobs](https://github.com/mwinters0/hnjobs) Find your next job on Who's Hiring


### PR DESCRIPTION
Adds [herdr](https://github.com/ogulcancelik/herdr) to the Productivity section (alphabetically, between `helm` and `hledger-ui`).

herdr is a terminal multiplexer and workspace manager for AI coding agents. It organizes terminals into workspaces, tabs, and panes, supports detach/reattach (including over SSH), tmux-style prefix keys plus mouse interaction, and ships as a single Rust binary (no Electron).