### PR TITLE
Add mxmon

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [lazyslurm](https://github.com/hill/lazyslurm) A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
 - [ls-horizons](https://github.com/litescript/ls-horizons) Terminal UI for visualizing NASA's Deep Space Network in real-time
 - [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
+- [mxmon](https://github.com/yusufmo1/mxmon) Sudoless Apple Silicon system monitor with per-process watts, a live chassis heat map, and a JSON contract for scripts and agents, written in Rust
 - [nerdlog](https://github.com/dimonomid/nerdlog) fast, remote-first, multi-host TUI log viewer
 - [nethogs](https://github.com/raboof/nethogs) 'net top' tool
 - [netscanner](https://github.com/Chleba/netscanner) Network scanner


### PR DESCRIPTION
Adds [mxmon](https://github.com/yusufmo1/mxmon) to Dashboards.

A sudoless Apple Silicon system monitor (interactive TUI, does not wrap another command, actively maintained): per-process energy in watts, a live chassis thermal map, and a headless JSON contract for scripts and agents. MIT, on crates.io, built with ratatui.