### PR TITLE
Add quinto to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [psnet](https://github.com/marlocarlo/psnet) Real-time TUI network monitor for Windows with speed graphs, DNS resolution, and packet inspection.
 - [pstop](https://github.com/marlocarlo/pstop) htop-style system monitor for Windows with per-core CPU bars, tree view, and 7 color schemes.
 - [Puffin](https://github.com/siddhantac/puffin) A beautiful terminal dashboard for hledger
+- [quinto](https://github.com/Tvk-sd/quinto) Web analytics in your terminal, synced to a local SQLite file that you or your agent can query with SQL
 - [Raijin](https://github.com/MasonStooksbury/Raijin) A free, simple weather TUI that pulls data without the need for an API key, account, or subscription
 - [rustnet](https://github.com/domcyrus/rustnet) A cross-platform network monitoring tool with deep packet inspection
 - [s-tui](https://github.com/amanusk/s-tui) CPU stress and monitoring utility


### PR DESCRIPTION
[quinto](https://github.com/Tvk-sd/quinto) — web analytics in your terminal.

It syncs pageviews from GoatCounter into a local SQLite file and reads them from there. One row per visit, expandable to the path that visitor took through the site. There's an overview screen too, and a `/` filter that matches pages *inside* a visit, so you can find people who reached a page second or third rather than only those who landed on it.

It's aimed at small sites, where aggregate dashboards mostly report noise, so it shows the visits themselves rather than percentages, and is deliberate about not implying precision it doesn't have (unmeasurable visit durations render as `—`, not `0s`; bots are hidden but counted, never deleted).

Because the data is a plain SQLite file, `quinto query` lets you or an agent ask things the screens don't cover, at the cost of one shell command.

- Go, Bubble Tea, no cgo — single static binary for macOS and Linux, amd64 and arm64
- `quinto demo` generates sample traffic, so it can be tried without an analytics account
- MIT