### PR TITLE
Add mirador to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [lazyslurm](https://github.com/hill/lazyslurm) A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
 - [ls-horizons](https://github.com/litescript/ls-horizons) Terminal UI for visualizing NASA's Deep Space Network in real-time
 - [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
+- [mirador](https://github.com/jchultarsky/mirador) A personal dashboard with world clocks, calendar and .ics agenda, weather, tasks, notes, a market watchlist, and live CPU and network graphs
 - [nerdlog](https://github.com/dimonomid/nerdlog) fast, remote-first, multi-host TUI log viewer
 - [nethogs](https://github.com/raboof/nethogs) 'net top' tool
 - [netscanner](https://github.com/Chleba/netscanner) Network scanner


### PR DESCRIPTION
[mirador](https://github.com/jchultarsky/mirador) — a personal dashboard for the terminal, in Rust and ratatui.

World clocks, a calendar and an `.ics` agenda, weather, a full task list with due dates and priorities, notes, a market watchlist and live CPU and network graphs, in a configurable grid.

It is built for one job: a tab you leave open all day and glance at. Nothing blinks, unfocused panels dim, and it redraws only when something visibly changes.

- **MIT** · macOS, Linux and Windows, with prebuilt binaries and one-line installers
- https://crates.io/crates/mirador

Added to *Dashboards*, alphabetically between `macmon` and `nerdlog`.