### PR TITLE
Add Paca to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nless](https://github.com/mpryor/nothing-less) Terminal pager for exploring tabular data with vi keybindings and automatic delimiter inference
 - [numr](https://github.com/nasedkinpv/numr) A natural language calculator with unit/currency conversions and vim-style keybindings
 - [openmux](https://github.com/monotykamary/openmux) A terminal multiplexer with master-stack layout (Zellij-style)
+- [Paca](https://github.com/wes/paca) Task, timer, and Stripe invoicing for projects, with local-first SQLite storage
 - [pagerduty-tui](https://github.com/Mk555/pagerduty-tui) Minimalistic terminal UI to manage triggered incidents
 - [patat](https://github.com/jaspervdj/patat) Terminal-based presentations using Pandoc
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support


### PR DESCRIPTION
Adding [Paca](https://github.com/wes/paca) to **Productivity** — a TUI for tracking project time and billing for it without leaving the terminal. Tasks, timers, timesheets, and Stripe draft invoices generated straight from uninvoiced time entries. All data local-first in SQLite; vim-style navigation.

![demo](https://raw.githubusercontent.com/wes/paca/main/docs/paca-demo.gif)

Against the requirements in the PR template:

- **6+ months old** — repo created 2026-01-19, actively maintained (latest release v0.1.22, 2026-07-24).
- **Unique** — the Productivity section has time trackers and expense trackers, but nothing that closes the loop from tracked time to an issued invoice.
- **Not a wrapper** — standalone TUI, not a frontend over another interactive command.
- **Interactive** — full-screen redrawing TUI (Bun + TypeScript), not an output formatter.

MIT licensed, installable via `npm i -g pacatui`. Entry placed alphabetically between `openmux` and `pagerduty-tui`, matching the existing one-line format.
