### PR TITLE
Add Portato

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support
 - [pkm](https://github.com/wick3dr0se/pkm) A super minimal TUI package manager wrapper written in BASH v4.2+
 - [pomo](https://github.com/Bahaaio/pomo) A minimal, customizable TUI Pomodoro timer with ASCII art, progress bar, desktop notifications, and productivity statistics. 
+- [Portato](https://github.com/portuber/portato) SSH port-forwarding manager with a TUI — toggle local, remote and SOCKS5 tunnels from one screen, with a background daemon and system autostart
 - [portfolio_rs](https://github.com/MarkusZoppelt/portfolio_rs) A command line tool for managing financial investment portfolios.
 - [pream-team](https://github.com/nikoladucak/pream-team/) a TUI utility that helps you keep track of your teams GitHub PRs across multiple repositories
 - [presenterm](https://github.com/mfontanini/presenterm) A markdown terminal slideshow tool


### PR DESCRIPTION
Adds [Portato](https://github.com/portuber/portato) to Productivity, alphabetically between `pomo` and `portfolio_rs`.

Portato is a TUI/CLI for managing SSH port-forwarding tunnels (`-L` / `-R` / `-D`): named tunnels in a config, toggle/restart/logs from one screen, optional background daemon with system autostart. Single Go binary, native SSH.

Complements existing SSH entries (LazySSH, sshm, ttm, lssh, termscp), which focus on sessions, shells, or file transfer — Portato's primary purpose is managed, persistent port forwards.

Landing page + demo GIF: https://portuber.github.io/portato/

- Repo: https://github.com/portuber/portato
- Latest release: v1.0.1
- License: MIT