### PR TITLE
Add agent-manager to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [agent-manager](https://github.com/YoanWai/agent-manager) Supervise, review, and answer AI coding agents running as tmux sessions, with an in-terminal git diff reviewer
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
agent-manager is a TUI for running several AI coding agents at once. Claude Code, Codex, OpenCode and Grok each run in their own tmux session and show up in one list with a live status, so you can see which agent is working and which is blocked on you.

Beyond the session list it does the review side: ctrl+r opens what an agent changed as whole files with the diff highlighted, and a comment left on a line is sent back into that agent's pane as a prompt.

Go, MIT, macOS and Linux, single binary. https://github.com/YoanWai/agent-manager

Placed alphabetically in Development between act3 and amtui.