### PR TITLE
Add amtr to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Dashboards</h2></summary>
 
 - [AdGuardian-Term](https://github.com/lissy93/AdGuardian-Term) A TUI dashboard for monitoring real-time traffic from an AdGuard Home instance
+- [amtr](https://github.com/arian-shamaei/anthropometer) A btop-style monitor for Claude Code sessions: live context-window map, cache economics, and compaction forensics
 - [apachetop](https://github.com/tessus/apachetop) display information from a running copy of Apache.
 - [atop](https://github.com/Atoptool/atop/) root level system and process monitor for Linux
 - [Backlog.md](https://github.com/MrLesk/Backlog.md) A tool for managing project collaboration between humans and AI Agents in a git ecosystem


### PR DESCRIPTION
Adds [amtr](https://github.com/arian-shamaei/anthropometer) — a btop-style monitor for Claude Code sessions (live context-window memory map, per-turn cache economics, compaction forensics; ratatui + Python). Placed alphabetically in Dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)