### PR TITLE
Add Gitside

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [gitv](https://github.com/jayanaxhf/gitv): A beautiful, feature-rich and performant terminal client for GitHub issues.
 - [git-crecord](https://github.com/andrewshadura/git-crecord) interactive selective commit tool
 - [git-scope](https://github.com/Bharath-code/git-scope) Terminal UI dashboard for inspecting multiple local Git repositories.
+- [Gitside](https://github.com/dev-bhaskar8/gitside) A responsive, mouse-friendly Git source-control TUI for full terminals and narrow tmux panes.
 - [grv](https://github.com/rgburke/grv) Terminal interface for viewing git repositories
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
 - [hcom](https://github.com/aannoo/hcom) CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals


### PR DESCRIPTION
## Summary

- Add Gitside to the Development section.

Gitside is a responsive, mouse-friendly Git source-control TUI designed for full terminals and narrow tmux panes.

The entry follows the existing list format and links to the public MIT-licensed repository.
