### PR TITLE
Add malevich to Rust libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <h3>Rust</h3>
 
 - [iocraft](https://github.com/ccbrown/iocraft) **Rust** crate for beautiful, artisanally crafted TUIs and text-based IO, with a declarative, React-like API inspired by Ink.
+- [malevich](https://github.com/shergin/malevich) A **Rust** terminal plotting library (line, scatter, bar, histogram, heatmap, box plot, violin) with automatic axes and an optional Ratatui widget.
 - [Ratatui](https://github.com/tui-rs-revival/ratatui) A **Rust** crate for building Terminal UIs (actively maintained fork of tui-rs).
 - [tui-input](https://github.com/sayanarijit/tui-input) TUI input library supporting multiple backends, tui-rs and ratatui in **Rust**
 - [tui-rs](https://github.com/fdehau/tui-rs) Terminal user interfaces and dashboards using **Rust** (no longer maintained, use Ratatui instead).


### PR DESCRIPTION
A Rust terminal plotting library (line, scatter, bar, histogram, heatmap, box plot, violin) with automatic axes and an optional Ratatui widget.