### PR TITLE
Add raygun to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [qo](https://github.com/kiki-ki/go-qo) Interactive SQL filter for JSON, CSV, TSV and other streams.
 - [qrypad](https://github.com/wheelibin/qrypad) A terminal SQL client for Postgres, MySQL and SQLite. 
 - [rainfrog](https://github.com/achristmascarl/rainfrog) A database management TUI for Postgres, MySQL, and SQLite written in Rust
+- [raygun](https://github.com/yetidevworks/raygun) A terminal receiver for Spatie's Ray debugger, speaking the same HTTP protocol as the desktop app, for PHP, Laravel and Grav
 - [regex-tui](https://github.com/vitor-mariano/regex-tui) A simple TUI to visualize and test regular expressions
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.
 - [runme](https://github.com/stateful/runme) Discover and run code snippets directly from your README.md or other markdowns


### PR DESCRIPTION
Adds [raygun](https://github.com/yetidevworks/raygun), a terminal receiver for Spatie's Ray debugger. It implements the same HTTP interface as the desktop Ray app and renders payloads in a Rust/ratatui TUI, for PHP, Laravel and Grav.

Interactive TUI, not an output formatter, and not a wrapper around another interactive command. First commit 2025-10-12, so it clears the 6 month age requirement.