### PR TITLE
Add ytunnel to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [WifUI](https://github.com/sohamw03/wifui) TUI for managing Wi-Fi connections on Windows natively (Rust)
 - [xplr](https://github.com/sayanarijit/xplr) A hackable, minimal, fast TUI file explorer, stealing ideas from nnn and fzf.
 - [x-cmd](https://github.com/x-cmd/x-cmd) A vast and interesting collection of tools that can then bootstrap lots of other programs / functions in a consistent and structured way.
+- [ytunnel](https://github.com/yetidevworks/ytunnel) A TUI for creating and managing Cloudflare Tunnels with custom domains
 
 ---
 


### PR DESCRIPTION
Adds [ytunnel](https://github.com/yetidevworks/ytunnel), a ratatui TUI for creating and managing Cloudflare Tunnels with custom domains.

Placed in Miscellaneous alongside the other networking tools there (vortix, WG Commander, wifitui, wavemon), since there is no dedicated networking section.

Interactive TUI, not an output formatter, and not a wrapper around another interactive command. First commit 2026-01-20, so it clears the 6 month age requirement.