### PR TITLE
Add DevProjex to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [ddv](https://github.com/lusingander/ddv) Terminal DynamoDB viewer
 - [delta](https://github.com/dandavison/delta) A syntax-highlighting pager for git, diff, and grep output
 - [deputui](https://github.com/twiddler/deputui) Review and install NPM package updates
+- [DevProjex](https://github.com/Avazbek22/DevProjex) A cross-platform TUI for exploring project trees, selecting files, previewing AI-ready context, and exporting structured codebase snapshots.
 - [differ](https://github.com/JanSmrcka/differ) A TUI git diff viewer
 - [euporie](https://github.com/joouha/euporie) Jupyter notebooks in the terminal
 - [fast-resume](https://github.com/angristan/fast-resume) Index and fuzzy search coding agent sessions


### PR DESCRIPTION
Adds DevProjex to the Development section.\n\nDevProjex now includes a keyboard-first terminal workspace for exploring project trees, selecting files, previewing structured context, and exporting the result. It runs with devprojex tui and is available in the current public release.\n\nProject: https://github.com/Avazbek22/DevProjex