### PR TITLE
Add qwen-audio-agent voice TUI to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [pyautogit](https://github.com/jwlodek/pyautogit) A terminal UI for managing git repositories, written using py_cui
 - [qo](https://github.com/kiki-ki/go-qo) Interactive SQL filter for JSON, CSV, TSV and other streams.
 - [qrypad](https://github.com/wheelibin/qrypad) A terminal SQL client for Postgres, MySQL and SQLite. 
+- [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) Realtime full-duplex voice TUI for AI coding agents (Claude Code, Codex, OpenCode, Kimi over ACP) — talk hands-free with barge-in, background task results read back, and a local wake word
 - [rainfrog](https://github.com/achristmascarl/rainfrog) A database management TUI for Postgres, MySQL, and SQLite written in Rust
 - [regex-tui](https://github.com/vitor-mariano/regex-tui) A simple TUI to visualize and test regular expressions
 - [resterm](https://github.com/unkn0wn-root/resterm) A terminal client for HTTP/GraphQL/gRPC with support for WebSockets, SSE, workflows, profiling, OpenAPI and response diffs.


### PR DESCRIPTION
Adds [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) to the **Development** section, alphabetical position between `qrypad` and `rainfrog`.

It's a realtime full-duplex voice TUI for AI coding agents — the terminal lets you talk hands-free to Claude Code / Codex / OpenCode / Kimi (over ACP), with barge-in, background task results read back into the conversation, and a fully local wake word. Fits alongside the existing agent entries (`amux`, `hcom`, `opencode`).

Disclosure: I'm a maintainer. Happy to adjust wording or placement.
