### PR TITLE
Add jind-ai to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [harlequin](https://github.com/tconbeer/harlequin) The SQL IDE for Your Terminal
 - [hcom](https://github.com/aannoo/hcom) CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
+- [jind-ai](https://github.com/takaaki-s/jind-ai) Run coding-agent sessions in tmux panes and see at a glance which one is working, idle, or waiting on you
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands


### PR DESCRIPTION
Adds jind-ai to Development.

It runs each coding-agent session in its own tmux pane and lists all of them with their status, repository and branch, so you can see which one is waiting on you. I am the author.