### PR TITLE
Add Raxol (Elixir) to Libraries/Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nocterm](https://github.com/Norbert515/nocterm) A Flutter-like TUI framework for **Dart** with hot reload, 45+ components, and declarative UI patterns.
 - [OpenTUI](https://github.com/sst/opentui) A **TypeScript** library for building terminal user interfaces (TUIs)
 - [php-tui](https://github.com/php-tui/php-tui) comprehensive TUI library for **PHP** based heavily on Ratatui.
+- [Raxol](https://github.com/DROOdotFOO/raxol) A multi-surface runtime for **Elixir**: one application renders to the terminal, browser, SSH, and agent surfaces, with per-component crash isolation and hot reload from the BEAM.
 - [termbox2](https://github.com/termbox/termbox2) A terminal rendering library for creating TUIs.
 - [TermGL](https://github.com/wojciech-graj/TermGL) A terminal-based graphics library for 2D and 3D graphics.
 - [Thermage](https://github.com/thermage/thermage) Thermage is a **PHP** library that provides a fluent and incredibly powerful, object-oriented interface for customizing CLI output text color, background, formatting, theming and more.


### PR DESCRIPTION
[Raxol](https://github.com/DROOdotFOO/raxol) is a multi-surface runtime for Elixir/OTP. One application module renders to the terminal, the browser, SSH, and an agent surface, so the same UI code serves all four.

Added to **Libraries → Other**, alphabetically before `termbox2`, with the language bolded to match the surrounding entries. Elixir has no subsection today, so Other seemed the right home rather than creating one for a single entry — happy to move it if you would prefer an `<h3>Elixir</h3>`.

What is genuinely different about it, rather than "another TUI library": it inherits OTP's supervision, so a component that crashes is restarted by its supervisor without taking the application down, and code can be swapped while it runs. The terminal backend is a NIF over [termbox2](https://github.com/termbox/termbox2), which is already on this list, with a pure-Elixir fallback driver on Windows.

Maintained and actively released — MIT, on Hex, with docs on HexDocs.
