### PR TITLE
Add memcode to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [logradar](https://github.com/nanook72/logradar) A fast Rust TUI for interactive log filtering and highlighting.
 - [LogLens](https://github.com/Caelrith/loglens-core) A structured log viewer and query engine for the terminal.
 - [logshark](https://github.com/ugosan/logshark) A debugger CLI for JSON logs written in Go
+- [memcode](https://github.com/memcode-ai/memcode) The coding agent that remembers your repo, with a full terminal UI and persistent per-project memory
 - [mitmproxy](https://www.mitmproxy.org) A free and open source interactive HTTPS proxy
 - [models](https://github.com/arimxyer/models) TUI for browsing AI models and coding agents
 - [nap](https://github.com/maaslalani/nap) Code snippets in your terminal


### PR DESCRIPTION
Adds **memcode** to Development (alphabetical, before mitmproxy).

The coding agent that remembers your repo: a full terminal UI (single Go binary) with persistent per-project memory in a local `.memcode` store. Runs on your own API keys, a hosted gateway, or local Ollama. MIT.

Repo: https://github.com/memcode-ai/memcode