### PR TITLE
Add Atomic Agent to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) Local-first AI coding agent with a terminal UI, running open-weight models entirely on your machine
 - [austin-tui](https://github.com/P403n1x87/austin-tui) The top-like text-based user interface for Austin
 - [blinkenlights](https://github.com/jart/blink) TUI that may be used for debugging x86_64-linux or i8086 programs across platforms
 - [brows](https://github.com/rubysolo/brows) CLI GitHub release browser


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent, thanks for maintaining this great list of TUIs.

Atomic Agent is a local-first coding agent with a terminal UI (built on React + ink), plus a CLI. It runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key needed to install. It sits right alongside the coding-agent TUIs already in the Development section (codex, crush, opencode).

One honest note on your 6-month age rule: our repo is about 4 months old, so the age bot will likely flag it. But it is an active project (~2k stars) maintained by the AtomicBot-ai organization, which ships several established projects. If you'd prefer we resubmit once it clears 6 months, totally understood, just wanted to put it on your radar now.

Links:
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT)
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs

Placed alphabetically in Development (after ATAC, before austin-tui). Thanks for the consideration!
