### PR TITLE
Add claudectl to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [Brief](https://github.com/WilliamAGH/brief) Terminal-first OpenAI chat client with slash-command palette and local tool execution.
 - [calcure](https://github.com/anufrievroman/calcure) Modern TUI calendar and task manager with minimal and customizable UI.
 - [calcurse](https://calcurse.org/) calendar and scheduling application for the command line
+- [claudectl](https://github.com/babarmuhammad/claudectl) Workspace manager for Claude Code sessions with persistent project memory and MCP awareness
 - [clipse](https://github.com/savedra1/clipse) TUI-based clipboard manager application
 - [Chronos](https://github.com/samuelstranges/chronos) A Vimlike Calendar TUI
 - [Desktop-TUI](https://github.com/Julien-cpsn/desktop-tui) A desktop environment without graphics


### PR DESCRIPTION
claudectl is a TUI for managing Claude Code sessions: it browses and searches every past session per project, maintains a token-budgeted project memory, shows which MCP servers a project has configured, and stores per-project launch settings. Python 3.10+, standard library only, MIT.

Sits next to agent-deck in scope. It has its own interactive UI rather than wrapping one — launching Claude Code is one action among the session browser, memory, MCP, hooks and usage screens.

Thank you for wanting to contribute to this list! There are many amazing terminal applications and our goal is to provide a curated list for people to discover them.

There are a few requirements for adding new applications to the list.

- **Repos need to be at least 6 months old**
- Applications should be unique
- Interfaces should be unique. Please don't submit wrappers (e.g. `fzf`)
- Interfaces should be interactive or re-draw output. Output formatters are not considered TUIs
