### PR TITLE
Add peek — htop for codebases to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [peek](https://github.com/hariomlohardev/peek) - The htop for codebases — understand any repo in 5 seconds. Python + Rich + Textual TUI (`pip install peek-code && peek .`), live `◐` pulse + `t` theme cycle, PageRank `Start Here`.
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
### What

Adds [peek](https://github.com/hariomlohardev/peek) — *the htop for codebases* — to **Development**.

- **One-liner:** `pip install peek-code && peek .` → 5 seconds to see languages, stack, `Start Here` ranked, and import graph
- **Stack:** Python + Rich + **Textual** TUI, 10 themes, `peek .` live `◐` pulse + `t` theme cycle + `w` watch, `peek --no-tui` for screenshots, `peek graph --format svg`
- **Why it fits:** It’s a **TUI** app (Textual) for codebases — interactive, not a wrapper like `fzf`. Fits **Development** alongside `lazygit`/`harlequin`/`posting`.

### Checklist

- [x] One-line description follows the list’s style
- [x] Link to GitHub repo
- [x] Fits **Development** (TUI for codebases)
- [x] Maintained (146 tests, `peek-code` on PyPI, `v0.3.0`)

Thanks! :sparkles:

*Live at https://github.com/hariomlohardev/peek — demo `peek/assets/demo.gif` 800×450.*