### PR TITLE
Add livetennis-tui (live tennis scores)

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [keydex](https://github.com/shikaan/keydex) TUI password manager for KeePass databases.
 - [lazynginx](https://github.com/giacomomasseron/lazynginx) Simple TUI for nginx management.
 - [LearnByExample](https://github.com/learnbyexample/TUI-apps) A TUI with tutorials and +300 exercises on python, grep, awk, sed & general terminal usage.
+- [livetennis-tui](https://github.com/livetennisapi/livetennis-tui) Live tennis scores in your terminal — ATP, WTA, Challenger and ITF, with fixtures and player search
 - [lnav](https://lnav.org/) An advanced log file viewer for the small-scale
 - [mac-cleanup-go](https://github.com/2ykwang/mac-cleanup-go) macOS disk cleanup TUI: scan cache/dev artifacts, preview, exclude, and move items to Trash.
 - [mapscii](https://github.com/rastapasta/mapscii) Braille & ASCII world map renderer for your console


### PR DESCRIPTION
Adds [livetennis-tui](https://github.com/livetennisapi/livetennis-tui) to **Miscellaneous** (alphabetical, next to golazo's soccer scores as the sports-scores precedent).

It's a Textual (Python) TUI for live tennis: in-play matches across ATP/WTA/Challenger/ITF with per-set scores, current points, serving marker and derived break-point flag, plus upcoming fixtures and player search. MIT, tested (pytest + Textual pilot, CI on Python 3.10–3.13), real SVG screenshots in the README. Works on the API's free tier and is honest about its rate limits (shows your remaining daily quota in the footer and pauses refresh when it's spent).

Disclosure: I maintain the API it uses.