### PR TITLE
Add p2pmux to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [nless](https://github.com/mpryor/nothing-less) Terminal pager for exploring tabular data with vi keybindings and automatic delimiter inference
 - [numr](https://github.com/nasedkinpv/numr) A natural language calculator with unit/currency conversions and vim-style keybindings
 - [openmux](https://github.com/monotykamary/openmux) A terminal multiplexer with master-stack layout (Zellij-style)
+- [p2pmux](https://github.com/pelazas/p2pmux) A peer-to-peer multiplayer terminal multiplexer where every pane runs on its owner's own machine
 - [pagerduty-tui](https://github.com/Mk555/pagerduty-tui) Minimalistic terminal UI to manage triggered incidents
 - [patat](https://github.com/jaspervdj/patat) Terminal-based presentations using Pandoc
 - [pdiary](https://github.com/manipuladordedados/pdiary) A simple terminal diary journal application written in Python with encryption support


### PR DESCRIPTION
[p2pmux](https://github.com/pelazas/p2pmux) — a terminal multiplexer with Zellij-like tabs, panes and nested splits, except the grid spans machines.

Every pane is a PTY on the machine of whoever opened it, with that machine's shell, PATH and env. You join a session with a ten-character code and land in a shared grid where some panes are on your laptop and some are on someone else's box; panes stream peer-to-peer, end-to-end encrypted, with relay fallback when NAT requires it. Presence shows who is on which tab, and taking control of a pane is just typing into it.

Interactive TUI, not a wrapper around another interactive command. macOS and Linux, MIT, Rust + ratatui. Installed with one line, no account and no server to run.

Placed in Productivity next to `tmux`, `zellij` and `openmux`, in alphabetical position between `openmux` and `pagerduty-tui`.