### PR TITLE
Add bada task manager app

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [awsui](https://github.com/junminhong/awsui) A powerful, user-friendly terminal interface for AWS Profile and SSO management.
 - [Bagels](https://github.com/EnhancedJax/Bagels) TUI expense tracker
 - [Brief](https://github.com/WilliamAGH/brief) Terminal-first OpenAI chat client with slash-command palette and local tool execution.
+- [Bada](https://github.com/Han8931/bada) A minimalist, Vim-first task manager designed to help you focus without distraction.
 - [calcure](https://github.com/anufrievroman/calcure) Modern TUI calendar and task manager with minimal and customizable UI.
 - [calcurse](https://calcurse.org/) calendar and scheduling application for the command line
 - [clipse](https://github.com/savedra1/clipse) TUI-based clipboard manager application


### PR DESCRIPTION
Adds [bada](https://github.com/Han8931/bada) to the Productivity section.

Bada is a keyboard-driven, Vim-first terminal task manager written in Go. It
keeps everything local in a SQLite database while offering the planning views
you'd normally leave the terminal for:

- **Agenda, Calendar, Gantt, and Statistics** views for planning at different scales
- **Projects and Kanban** boards with custom status pipelines
- Priorities, due/start dates, recurrence, tags, assignees, timezones, and notes
- Text and fuzzy search plus filters (overdue, today, this week, by stage)
- Configurable keybindings and seven built-in themes with full color customization