### PR TITLE
Add amtr to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
-- [amtr](https://github.com/arian-shamaei/anthropometer) A btop-style live monitor for Claude Code sessions: context-window memory map, file traffic, cache economics, and a compiled PDF report
+- [amtr](https://github.com/arian-shamaei/anthropometer) A btop-style live monitor for AI coding agents (Claude Code, Codex CLI): context-window memory map, file traffic, cache economics, and a compiled PDF report
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 <details open><summary><h2>Development</h2></summary>
 
 - [act3](https://github.com/dhth/act3) Glance at the last 3 runs of your Github Actions
+- [amtr](https://github.com/arian-shamaei/anthropometer) A btop-style live monitor for Claude Code sessions: context-window memory map, file traffic, cache economics, and a compiled PDF report
 - [amtui](https://github.com/pehlicd/amtui/) Alertmanager TUI - Your Terminal Companion for Alertmanager
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.


### PR DESCRIPTION
Adds [amtr](https://github.com/arian-shamaei/anthropometer) — a btop-style TUI that attaches to a Claude Code session's transcript and renders, live, what's happening inside the model's context window: a memory map of the token budget, file traffic, per-turn cache economics, and subagent fan-out; press R for a compiled PDF report. Rust + ratatui, MIT, on crates.io and Homebrew.

(Separate PR from #837/sgram-tui so each entry can be reviewed independently.)