### PR TITLE
Add Keen Code to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [hcom](https://github.com/aannoo/hcom) CLI and TUI for real-time messaging, observation, and orchestration between AI coding agents (Claude Code, Antigravity, Codex, OpenCode, Kilo, Cursor) across terminals
 - [heretek](https://github.com/wcampbell0x2a/heretek) GDB TUI Dashboard
 - [jqp](https://github.com/noahgorstein/jqp) A TUI playground to experiment with jq
+- [Keen Code](https://github.com/mochow13/keen-code) A context-aware terminal AI coding agent written in Go with multiple providers, MCPs, subagents, Agent Skills, controllable tool output retention, and hashline edits
 - [kagan](https://github.com/kagan-sh/kagan) AI-powered Kanban TUI for autonomous development workflows
 - [lazygit](https://github.com/jesseduffield/lazygit) Simple terminal UI for git commands
 - [lazymake](https://github.com/rshelekhov/lazymake) Modern TUI for Makefiles with interactive target selection, dependency visualization, and command safety analysis.


### PR DESCRIPTION
Adds [Keen Code](https://github.com/mochow13/keen-code) to the Development section.

Keen Code is an open-source, context-aware terminal AI coding agent written in Go. It supports multiple providers, MCPs, subagents, Agent Skills, controllable tool output retention, hashline edits, and more.

Its interactive terminal UI redraws output and includes model selection, permission prompts, context status, session management, and slash commands. The repository is more than six months old, actively maintained, and Keen is a standalone application rather than a wrapper.

Website: https://mochow13.github.io/keen-code/

Two notable (and uncommon) features of Keen Code:

- Turn Memory and controllable tool output retention: https://mochow13.github.io/keen-code/docs/turn-memory.html
- Skill-driven MCP integration: https://mochow13.github.io/keen-code/docs/mcp-skills.html