### PR TITLE
Add roost, leghorn, legbar to Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [kmon](https://github.com/orhun/kmon) Linux Kernel Manager and Activity Monitor
 - [Kyanos](https://github.com/hengyoush/kyanos) Linux network analysis tool based on eBPF
 - [lazyslurm](https://github.com/hill/lazyslurm) A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
+- [legbar](https://github.com/gmhoward9289-ops/legbar) TUI showing what your coding agents are doing - models, context windows, who is waiting for input - alongside your GitHub pipeline
+- [leghorn](https://github.com/gmhoward9289-ops/leghorn) Live Claude Code sessions joined to real git state and GitHub CI
 - [ls-horizons](https://github.com/litescript/ls-horizons) Terminal UI for visualizing NASA's Deep Space Network in real-time
 - [macmon](https://github.com/vladkens/macmon) Sudoless performance monitoring for Apple Silicon processors written in Rust
 - [nerdlog](https://github.com/dimonomid/nerdlog) fast, remote-first, multi-host TUI log viewer
@@ -85,6 +87,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [pstop](https://github.com/marlocarlo/pstop) htop-style system monitor for Windows with per-core CPU bars, tree view, and 7 color schemes.
 - [Puffin](https://github.com/siddhantac/puffin) A beautiful terminal dashboard for hledger
 - [Raijin](https://github.com/MasonStooksbury/Raijin) A free, simple weather TUI that pulls data without the need for an API key, account, or subscription
+- [roost](https://github.com/gmhoward9289-ops/roost) top for Claude Code - live sessions, models, context windows, and the subagents they spawn
 - [rustnet](https://github.com/domcyrus/rustnet) A cross-platform network monitoring tool with deep packet inspection
 - [s-tui](https://github.com/amanusk/s-tui) CPU stress and monitoring utility
 - [sacha](https://github.com/Sachamama/sacha) A two-pane AWS TUI for browsing, searching, and managing resources across seven services including CloudWatch Logs, S3, DynamoDB, Lambda, SSM, SQS, and EC2.


### PR DESCRIPTION
Three related terminal dashboards for watching coding-agent sessions, added alphabetically to the Dashboards section:

- **roost** - top for Claude Code: live sessions, models, context windows, and the subagents they spawn. Released on PyPI (`roost-top`), Homebrew, and winget.
- **leghorn** - live Claude Code sessions joined to real git state and GitHub CI, so you can see what an agent actually did. On PyPI.
- **legbar** - the combined view: agent activity alongside your GitHub pipeline.

All three are actively maintained (releases via release-please, multiple tagged releases each) and are standalone TUIs, not wrappers around other interactive commands.