### PR TITLE
Add bermuda to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [amux](https://github.com/andyrewlee/amux) Easily run parallel coding agents
 - [ATAC](https://github.com/Julien-cpsn/ATAC) A feature-full TUI API client made in Rust. ATAC is free, open-source, offline and account-less.
 - [austin-tui](https://github.com/P403n1x87/austin-tui) The top-like text-based user interface for Austin
+- [bermuda](https://github.com/bon5co/bermuda) TUI board for scheduling and orchestrating coding-agent jobs and multi-step flows on the herdr terminal multiplexer
 - [blinkenlights](https://github.com/jart/blink) TUI that may be used for debugging x86_64-linux or i8086 programs across platforms
 - [brows](https://github.com/rubysolo/brows) CLI GitHub release browser
 - [burf](https://github.com/razeghi71/burf) TUI for Google Cloud Storage (GCS)


### PR DESCRIPTION
Adds [bermuda](https://github.com/bon5co/bermuda), a TUI board for scheduling and orchestrating coding-agent jobs on the [herdr](https://herdr.dev) terminal multiplexer.

It's not a wrapper around another interactive command — the board (jobs, runs, flows, threads tabs) is its own bubbletea-based UI. It schedules agent jobs on a cron, runs declared multi-step "flows" whose steps an agent can't skip, and gives agents a shared thread/claim/forum record.

Written in Go, MIT licensed, actively maintained (in daily use on the author's own machine).

Placed alphabetically in the Development section, matching the existing one-line entry format.