### PR TITLE
Add passtui

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ There's a lot of cool projects here that I have no association with. Run them at
 - [oha](https://github.com/hatoo/oha) HTTP load generator
 - [packemon](https://github.com/ddddddO/packemon) Packet generator and monitor.
 - [pass-cli](https://github.com/arimxyer/pass-cli) A TUI and CLI password manager with rclone cloud syncing support
+- [passtui](https://github.com/fjmoralesp/passtui) The terminal user interface for **pass**, the standard unix password manager.
 - [PesterExplorer](https://github.com/HeyItsGilbert/PesterExplorer) A TUI to explore Pester results.
 - [pug](https://github.com/leg100/pug) terraform and tofu module and infrastructure management.
 - [physics-TUI](https://github.com/ClaudioRMalvino/physics_TUI) Physics TUI application for undergraduate study


### PR DESCRIPTION
PassTUI is a terminal user interface for **pass** — the standard Unix password manager. It brings a keyboard-driven, visual experience to your encrypted password store without ever leaving the terminal.

If you live in the terminal and want a fast, intuitive way to manage your GPG-encrypted passwords, PassTUI is for you.

Repository: https://github.com/fjmoralesp/passtui

<img width="800" alt="passtui" src="https://github.com/user-attachments/assets/ee2e56e4-e185-4425-9b6d-ccf589960ef2" />
